### PR TITLE
QEA-1205

### DIFF
--- a/lib/element.rb
+++ b/lib/element.rb
@@ -366,7 +366,7 @@ class Element
 
   def field_empty_afterward?(*args)
     Log.debug("Checking the field after sending #{args}, to see if it's empty")
-    check_again = (not args.empty? and no_symbols? *args)
+    check_again = (has_characters? *args and no_symbols? *args)
     field_is_empty_but_should_not_be = (check_again and field_empty?)
     if field_is_empty_but_should_not_be
       raise "Browser Error: tried to input #{args} but found an empty string afterward: #{value}"
@@ -401,6 +401,19 @@ class Element
       return true
     end
     false
+  end
+
+  #
+  # helper to check if *args is not empty but contains only empty string(s)/symbol(s)
+  # if so, don't bother trying to validate the text afterward
+  #
+
+  def has_characters?(*args)
+    characters = args.select { |_| not _.is_a? Symbol }.join('')
+    if characters.empty?
+      return false
+    end
+    true
   end
 
 end

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -123,6 +123,16 @@ describe Element do
       expect(actual_text).to eq ("1")
     end
 
+    it 'send_keys should be able to accept an empty string' do
+      Driver.visit test_input_page
+      expected_selector = "[id=\"input_1\"]"
+      this_one = Element.new expected_selector, :css, expected_selector
+      new_text = ""
+      this_one.send_keys new_text
+      actual_text = this_one.value
+      expect(actual_text).to eq (new_text)
+    end
+
     it 'should not clear the field when sending only symbols' do
       Driver.visit test_input_page
       expected_selector = "[id=\"input_1\"]"


### PR DESCRIPTION
In the midst of pivoting to handle symbols during text validation and checking for non-empty field instead of text equality, I failed to handle the case skipping the non-empty field check after sending an empty string to it.

*args is something I need to be much more careful with in the future.