### PR TITLE
QEA-1087: Move Gridium into SendGrid Public - Part 2

### DIFF
--- a/.jenkins-docker
+++ b/.jenkins-docker
@@ -22,7 +22,7 @@ _init_env() {
 }
 
 run_test(){
-  docker exec $(docker-compose ps -q gridium) rspec spec/s3_spec.rb
+  docker exec $(docker-compose ps -q gridium) rake spec
 }
 
 main() {

--- a/.jenkins-docker
+++ b/.jenkins-docker
@@ -18,11 +18,12 @@ _init_env() {
   export NAMESPACE
   export APPNAME
   export COMPOSE_PROJECT_NAME
+  export BUILD_NUMBER
 
 }
 
 run_test(){
-  docker exec $(docker-compose ps -q gridium) rake spec
+  docker exec $(docker-compose ps -q gridium) bundle install; rake spec
 }
 
 main() {

--- a/.jenkins-docker
+++ b/.jenkins-docker
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eux
+#set -o pipefail
+
+_init_env() {
+  # leading colon force successful return code
+  : ${PUBLISH:=0} # If unset, default to 0
+  : ${REGISTRY:=docker.sendgrid.net}
+  : ${NAMESPACE:=${USER}}
+  : ${APPNAME=gridium}
+  : ${COMPOSE_PROJECT_NAME:=$APPNAME}
+
+  # If we're "jenkins" and on the "origin/master" branch, push to 'docker.sendgrid.net/sendgrid'
+  [[ "${USER}" == "jenkins" ]] && [[ "${GIT_BRANCH}" == "origin/master" ]] && NAMESPACE=sendgrid
+
+  export PUBLISH
+  export REGISTRY
+  export NAMESPACE
+  export APPNAME
+  export COMPOSE_PROJECT_NAME
+
+}
+
+run_test(){
+  docker exec $(docker-compose ps -q gridium) rake spec
+}
+
+main() {
+  echo "**** Arguments: $@"
+
+  # Cleanup regardless
+  trap bin/cleanup EXIT
+
+  _init_env
+
+  if [[ "${SKIPDOCKERPULL:=0}" -eq 1 ]]; then
+    echo "Skipping docker pull"
+  else
+    bin/pull
+  fi
+
+  bin/start -i
+  sleep 2
+
+  run_test
+}
+
+
+main

--- a/.jenkins-docker
+++ b/.jenkins-docker
@@ -22,7 +22,7 @@ _init_env() {
 }
 
 run_test(){
-  docker exec $(docker-compose ps -q gridium) rake spec
+  docker exec $(docker-compose ps -q gridium) rspec spec/s3_spec.rb
 }
 
 main() {

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,3 @@ WORKDIR /gridium
 COPY . /gridium
 
 CMD gem install bundle;
-RUN bundle;

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in gridium.gemspec
 gemspec
-
-gem 'rspec-mocks'
-gem 'rspec'
-gem 'rake'
-gem 'dotenv'

--- a/bin/builder
+++ b/bin/builder
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+main() {
+  docker-compose up -d gridium
+
+  trap bin/cleanup EXIT
+
+  docker exec $(docker-compose ps -q gridium) bash -c "echo -e '---\n:rubygems_api_key: $1' >> ~/.gem/credentials; chmod 0600 ~/.gem/credentials; cat ~/.gem/credentials"
+  docker exec $(docker-compose ps -q gridium) bash -c "gem build gridium.gemspec"
+  docker exec $(docker-compose ps -q gridium) bash -c "gem push gridium-1.0.$BUILD_NUMBER.gem"
+}
+
+main $1

--- a/bin/cleanup
+++ b/bin/cleanup
@@ -6,6 +6,8 @@ main() {
   docker-compose rm -fv
 
   docker rmi $(docker images -f "dangling=true" -q)
+  #remove images created during this build
+  docker rmi -f $(docker images *_gridium -q)
 
   docker run -v /var/run/docker.sock:/var/run/docker.sock -v /var/lib/docker:/var/lib/docker --rm martin/docker-cleanup-volumes
 

--- a/bin/start
+++ b/bin/start
@@ -2,11 +2,15 @@
 
 main(){
   case $1 in
-    -i) #start normally
+    -i) #start normally - used for jenkins
       docker-compose up -d
+      docker exec $(docker-compose ps -q gridium) bundle install;
       ;;
     -d) #start in development mode
+      ${BUILD_NUMBER:=dev}
+      export BUILD_NUMBER
       docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+      docker exec $(docker-compose ps -q gridium) bundle install;
       ;;
     *)
       echo "Usage: $0 [-i] isolated [-d] gridium dev" 1>&2; exit 1;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,4 +21,5 @@ services:
       - S3_SECRET_ACCESS_KEY=$S3_SECRET_ACCESS_KEY
       - S3_DEFAULT_REGION=$S3_DEFAULT_REGION
       - S3_ROOT_BUCKET=$S3_ROOT_BUCKET
+      - BUILD_NUMBER=$BUILD_NUMBER
     command: "tail -f /dev/null"

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "1.0.1"
+  VERSION = "1.0.#{ENV['BUILD_NUMBER']}"
 end


### PR DESCRIPTION
Couple of Important Changes here:

When running in dev mode the build_number will be set to 'dev'.  This allows us to bundle install dev dependencies and work on changes in the docker dev environment.

The builder script was added to run from jenkins after tests have been run.  This will should deploy the gem to RubyGems on successful test.  

With this change we no longer have to manually increment the version number for minor changes.  The jenkins_build number will be tacked on to the version automatically.  

The Jenkins job will run tests on changes to master, and only deploy gem if tests are successful.  Failed tests on master will not deploy the broken gem.  Changes will need to be reverted out of master in this setup.