### PR TITLE
QEA-1180

### DIFF
--- a/lib/s3.rb
+++ b/lib/s3.rb
@@ -6,7 +6,7 @@ module Gridium
         DELIMITER = "/"
 
         def initialize(project_name, subdirectory_name='screenshots')
-            Log.debug("initializing GridiumS3 with #{project_name} and #{subdirectory_name}")
+            Log.debug("[GRIDIUM::S3] initializing GridiumS3 with #{project_name} and #{subdirectory_name}")
             Aws.config.update({ credentials: Aws::Credentials.new(ENV['S3_ACCESS_KEY_ID'], ENV['S3_SECRET_ACCESS_KEY']) , region: ENV['S3_DEFAULT_REGION']})
             _validate_string(project_name)
             _validate_string(subdirectory_name)
@@ -16,7 +16,7 @@ module Gridium
         end
 
         def save_file(absolute_path_of_file)
-            Log.debug("attempting to save #{absolute_path_of_file} to s3")
+            Log.debug("[GRIDIUM::S3] attempting to save #{absolute_path_of_file} to s3")
             _validate_path(absolute_path_of_file)
             file_name = File.basename(absolute_path_of_file)
             destination_name = create_s3_name(file_name)
@@ -27,11 +27,11 @@ module Gridium
               # @bucket.object(s3_name).presigned_url(:get, expires_in: 3600) #uncomment this if public url ends up not working out OPREQ-83850
               return @bucket.object(destination_name).public_url
             rescue Aws::S3::Errors::InvalidAccessKeyId
-              Log.error("unable to save file to s3 due to Aws::S3::Errors::InvalidAccessKeyId")
+              Log.error("[GRIDIUM::S3] unable to save file to s3 due to Aws::S3::Errors::InvalidAccessKeyId")
             rescue Seahorse::Client::NetworkingError => error
-              Log.error("unable to save file to s3 due to underlying network error: #{error}")
+              Log.error("[GRIDIUM::S3] unable to save file to s3 due to underlying network error: #{error}")
             rescue StandardErrer => error
-              Log.error("unable to save file to s3 due to unexpected error: #{error}")
+              Log.error("[GRIDIUM::S3] unable to save file to s3 due to unexpected error: #{error}")
             end
         end
 
@@ -49,23 +49,23 @@ module Gridium
         end
 
         def _validate_string(input_string)
-            Log.debug("attempting to validate #{input_string} for use as a name")
+            Log.debug("[GRIDIUM::S3] attempting to validate #{input_string} for use as a name")
             if input_string.empty? or input_string.strip().empty? then
-                raise(ArgumentError, "empty and/or whitespace file names are not wanted here.")
+                raise(ArgumentError, "[GRIDIUM::S3] empty and/or whitespace file names are not wanted here.")
             end
         end
 
         def _validate_path(path_to_file)
-            Log.debug("attmepting to validate #{path_to_file} as a legitimate path")
+            Log.debug("[GRIDIUM::S3]  attempting to validate #{path_to_file} as a legitimate path")
             if not File.exist? path_to_file then
-                raise(ArgumentError, "this path doesn't resolve #{path_to_file}")
+                raise(ArgumentError, "[GRIDIUM::S3] this path doesn't resolve #{path_to_file}")
             end
         end
 
         def _verify_upload(s3_name, local_absolute_path)
             upload_size = @bucket.object(s3_name).content_length
             local_size = File.size local_absolute_path
-            Log.debug("file upload verified: #{upload_size == local_size}. upload size is #{upload_size} and local size is #{local_size}")
+            Log.debug("[GRIDIUM::S3] file upload verified: #{upload_size == local_size}. upload size is #{upload_size} and local size is #{local_size}")
             upload_size == local_size
         end
     end

--- a/spec/s3_spec.rb
+++ b/spec/s3_spec.rb
@@ -27,10 +27,13 @@ describe GridiumS3 do
   end
 
   describe 's3 connectivity' do
-    it 'will gracefully handle a loss in connectivity' do
-
+    xit 'will gracefully handle a loss in connectivity' do
+      # need to figure out how to force s3 to encounter
+      # Seahorse::Client::NetworkingError after authenticating
+      # during this code: @bucket.object(destination_name).wait_until_exists
     end
   end
+
   describe 's3 configuration' do
 
       let(:s3_access_key_id) {ENV['S3_ACCESS_KEY_ID']}


### PR DESCRIPTION
Rescue errors when saving files to s3.
mako ui p1 jobs are really crudded up with errors like this:
```
Seahorse::Client::NetworkingError:
  Failed to open TCP connection to sg-qe-artifacts.s3.amazonaws.com:443 (getaddrinfo: Temporary failure in name resolution)
```

Not to mention when I invalidated the credentials recently and the same jobs caught on fire.

Also some whitespace that I cleaned up.

I don't have a test for the TCP error, but there is one for bad credentials which works. The rescue is in the same place so I'm confident it will work.

I want to revisit this and figure out how to force that error to happen in a test.