### PR TITLE
QEA-1073: Upgrade Selenium-Webdriver dependancy and build nodes

### DIFF
--- a/bin/builder
+++ b/bin/builder
@@ -7,7 +7,7 @@ main() {
 
   docker exec $(docker-compose ps -q gridium) bash -c "echo -e '---\n:rubygems_api_key: $1' >> ~/.gem/credentials; chmod 0600 ~/.gem/credentials; cat ~/.gem/credentials"
   docker exec $(docker-compose ps -q gridium) bash -c "gem build gridium.gemspec"
-  docker exec $(docker-compose ps -q gridium) bash -c "gem push gridium-1.0.$BUILD_NUMBER.gem"
+  docker exec $(docker-compose ps -q gridium) bash -c "gem push gridium-1.1.$BUILD_NUMBER.gem"
 }
 
 main $1

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,9 +1,11 @@
 version: '2'
 services:
-  chrome:
-    image: selenium/node-chrome-debug:3.1.0
+  hub:
     ports:
-      - "5900"
+      - "4444:4444"
+  chrome:
+    ports:
+      - "5900:5900"
   gridium:
     volumes:
       - $GRIDIUMPATH:/gridium

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,7 +1,9 @@
 version: '2'
 services:
-  firefox:
-    image: selenium/node-firefox-debug:3.1.0
+  chrome:
+    image: selenium/node-chrome-debug:3.1.0
+    ports:
+      - "5900"
   gridium:
     volumes:
       - $GRIDIUMPATH:/gridium

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,7 @@
 version: '2'
 services:
+  firefox:
+    image: selenium/node-firefox-debug:3.1.0
   gridium:
     volumes:
       - $GRIDIUMPATH:/gridium

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,8 @@ services:
     image: selenium/hub:3.1.0
     ports:
       - "4444"
-  firefox:
-    image: selenium/node-firefox:3.1.0
-    environment:
-      HUB_PORT_4444_TCP_ADDR: hub
-      HUB_PORT_4444_TCP_PORT: 4444
-    ports:
-      - "5900"
+  chrome:
+    image: selenium/node-chrome:3.1.0
     depends_on:
       - hub
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       HUB_PORT_4444_TCP_PORT: 4444
     ports:
       - "5900"
+    depends_on:
+      - hub
   mustadio:
     image: yetanotherlucas/mustadio
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,10 @@ services:
     image: selenium/hub:3.1.0
     ports:
       - "4444"
+    environment:
+      - GRID_BROWSER_TIMEOUT=30
   chrome:
-    image: selenium/node-chrome:3.1.0
+    image: selenium/node-chrome-debug:3.1.0
     depends_on:
       - hub
     environment:
@@ -13,6 +15,8 @@ services:
       - HUB_PORT_4444_TCP_PORT=4444
       - no_proxy=localhost
       - HUB_ENV_no_proxy=localhost
+    ports:
+      - "5900"
   mustadio:
     image: yetanotherlucas/mustadio
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     environment:
       HUB_PORT_4444_TCP_ADDR: hub
       HUB_PORT_4444_TCP_PORT: 4444
+    ports:
+      - "5900"
   mustadio:
     image: yetanotherlucas/mustadio
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,14 @@
 version: '2'
 services:
   hub:
-    image: sethuster/selenium-hub
+    image: selenium/hub:3.1.0
     ports:
       - "4444"
   firefox:
-    image: sethuster/node-firefox-debugx
-    ports:
-      - "5900"
-    depends_on:
-      - hub
+    image: selenium/node-firefox:3.1.0
+    environment:
+      HUB_PORT_4444_TCP_ADDR: hub
+      HUB_PORT_4444_TCP_PORT: 4444
   mustadio:
     image: yetanotherlucas/mustadio
     ports:

--- a/gridium.gemspec
+++ b/gridium.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~>2.3"
   spec.add_development_dependency "dotenv", "~>2.1"
 
-  spec.add_runtime_dependency "selenium-webdriver", ">= 2.50.0", "< 3"
+  spec.add_runtime_dependency "selenium-webdriver", "3.3.0"
   spec.add_runtime_dependency "oily_png", "~> 1.2"
   spec.add_runtime_dependency 'aws-sdk', '~> 2'
 end

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -127,7 +127,7 @@ class Element
         element.click
       rescue Exception => e
         Log.warn("[GRIDIUM::Element] Click Exception retrying...")
-        sleep 0.10
+        sleep 0.15
         click_retry -= 1
         if click_retry > 0
           retry

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -129,7 +129,7 @@ class Element
         Log.warn("[GRIDIUM::Element] Click Exception retrying...")
         sleep 0.15
         click_retry -= 1
-        if click_retry > 0
+        if click_retry >= 0
           retry
         else
           Log.error("[GRIDIUM::Element] Click Exception #{e}")

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -118,13 +118,26 @@ class Element
   end
 
   def click
-    Log.debug("Clicking on #{self}")
+    Log.debug("[GRIDIUM::Element] Clicking on #{self}")
+    click_retry = 2
     if element.enabled?
       ElementExtensions.highlight(self) if Gridium.config.highlight_verifications
       $verification_passes += 1
-      element.click
+      begin
+        element.click
+      rescue Exception => e
+        Log.warn("[GRIDIUM::Element] Click Exception retrying...")
+        sleep 0.10
+        click_retry -= 1
+        if click_retry > 0
+          retry
+        else
+          Log.error("[GRIDIUM::Element] Click Exception #{e}")
+          fail
+        end
+      end
     else
-      Log.error('Cannot click on element.  Element is not present.')
+      Log.error('[GRIDIUM::Element] Cannot click on element.  Element is not present.')
     end
   end
 

--- a/lib/gridium/version.rb
+++ b/lib/gridium/version.rb
@@ -1,3 +1,3 @@
 module Gridium
-  VERSION = "1.0.#{ENV['BUILD_NUMBER']}"
+  VERSION = "1.1.#{ENV['BUILD_NUMBER']}"
 end

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -141,7 +141,7 @@ module Gridium
     end
 
     def check(id) #checks a checkbox
-      Driver.driver.find_element(:id, id).click
+      Element.new("Checkbox", :id, id).click
     end
   end
 

--- a/lib/testrail.rb
+++ b/lib/testrail.rb
@@ -81,17 +81,19 @@ module Gridium
       closed = false
       if Gridium.config.testrail && !@run_info[:error]
         Log.debug("[GRIDIUM::TestRail] Closing test runid: #{@run_info[:id]}\n")
-        r = _send_request('POST', "#{@url}update_run/#{@run_info[:id]}", {:case_ids => @tc_ids})
-        Log.debug("[GRIDIUM::TestRail] UPDATE RUN: #{r}")
-        sleep 0.25
-        r = _send_request('POST', "#{@url}add_results_for_cases/#{@run_info[:id]}", {results: @tc_results})
-        Log.debug("[GRIDIUM::TestRail] ADD RESULTS: #{r}")
-        sleep 0.25
-        Log.debug("#{r.class}")
-        if r.is_a?(Hash)
-          r = _send_request('POST', "#{@url}update_run/#{@run_info[:id]}", {:name => "ER:#{@run_info[:name]}", :description => "#{@run_info[:desc]}\nThe following was returned when adding cases: #{r}"})
-          Log.warn("[GRIDIUM::TestRail] ERROR: #{r}")
+        if @tc_ids.size > 0
+          r = _send_request('POST', "#{@url}update_run/#{@run_info[:id]}", {:case_ids => @tc_ids})
+          Log.debug("[GRIDIUM::TestRail] UPDATE RUN: #{r}")
           sleep 0.25
+          r = _send_request('POST', "#{@url}add_results_for_cases/#{@run_info[:id]}", {results: @tc_results})
+          Log.debug("[GRIDIUM::TestRail] ADD RESULTS: #{r}")
+          sleep 0.25
+          Log.debug("#{r.class}")
+          if r.is_a?(Hash)
+            r = _send_request('POST', "#{@url}update_run/#{@run_info[:id]}", {:name => "ER:#{@run_info[:name]}", :description => "#{@run_info[:desc]}\nThe following was returned when adding cases: #{r}"})
+            Log.warn("[GRIDIUM::TestRail] ERROR: #{r}")
+            sleep 0.25
+          end
         end
         r = _send_request('POST', "#{@url}close_run/#{@run_info[:id]}", nil)
         Log.debug("[GRIDIUM::TestRail] CLOSE RUN: #{r}")

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -35,7 +35,7 @@ describe Driver do
   describe '#driver' do
     it 'sets browser configuration' do
       expect(gridium_config.browser_source).to eq :remote
-      expect(gridium_config.browser).to eq :firefox
+      expect(gridium_config.browser).to eq :chrome
 
       test_driver.driver
     end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -10,7 +10,7 @@ describe Element do
   before :all do
     Gridium.config.browser_source = :remote
     Gridium.config.target_environment = "http://hub:4444/wd/hub"
-    Gridium.config.browser = :firefox
+    Gridium.config.browser = :chrome
   end
 
   after :each do

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -100,7 +100,8 @@ describe Element do
       expect(new_text).to eq (original_text + text_to_append)
     end
 
-    it 'should be able to send symbols for keys' do
+    it 'should be able to send printable symbols for keys' do
+      skip "This is officially broken on the Selenium Server 3.1.0: https://github.com/SeleniumHQ/selenium/issues/2704"
       Driver.visit test_input_page
       expected_selector = "[id=\"input_1\"]"
       this_one = Element.new expected_selector, :css, expected_selector
@@ -108,6 +109,30 @@ describe Element do
       this_one.send_keys new_text, :space, "1"
       actual_text = this_one.value
       expect(actual_text).to eq (new_text + " " + "1")
+    end
+
+    it 'should be able to send return symbol for keys' do
+      Driver.visit test_input_page
+      expected_selector = "[id=\"input_1\"]"
+      this_one = Element.new expected_selector, :css, expected_selector
+      initial_text = this_one.value #foo
+      this_one.clear
+      this_one.send_keys :enter
+      new_text = this_one.value #foo again
+      expect(new_text).to eq (initial_text)
+    end
+
+    it 'should be able to send tab symbol for keys' do
+      Driver.visit test_input_page
+      first_selector = "[id=\"input_1\"]"
+      second_selector = "[id=\"input_2\"]"
+      this_one = Element.new first_selector, :css, first_selector
+      next_one = Driver.driver.find_element(:css => second_selector)
+      new_text = "#{SecureRandom.uuid}"
+      this_one.send_keys new_text, :tab
+      focused = Driver.driver.switch_to.active_element #might fail
+      Log.debug "focused is #{focused} next one is #{next_one}"
+      expect(next_one).to eq (focused)
     end
 
     it 'should be able to accept numbers' do

--- a/spec/gridium_spec.rb
+++ b/spec/gridium_spec.rb
@@ -16,7 +16,7 @@ describe Gridium do
         expect(gridium_configuration.report_dir).to eq "./test_results"
         expect(gridium_configuration.browser_source).to eq(:remote)
         expect(gridium_configuration.target_environment).to eq('http://hub:4444/wd/hub')
-        expect(gridium_configuration.browser).to eq(:firefox)
+        expect(gridium_configuration.browser).to eq(:chrome)
         expect(gridium_configuration.page_load_timeout).to eq(15)
         expect(gridium_configuration.element_timeout).to eq (15)
         expect(gridium_configuration.visible_elements_only).to be(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ Gridium.configure do |config|
   config.report_dir = "./test_results"
   config.browser_source = :remote
   config.target_environment = "http://hub:4444/wd/hub"
-  config.browser = :firefox
+  config.browser = :chrome
   config.url = "http://www.sendgrid.com"
   config.page_load_timeout = 15
   config.element_timeout = 15


### PR DESCRIPTION
So this is pretty awesome - what we have here is basically removes our dependancy on building our own Selenium nodes to use Docker DNS.  We'll move into tagged versions of Selenium Server build nodes maintained by the SeleniumHQ.  This means we can keep them pinned to known good versions and change them after testing.

We will need to make a change to our internal harnesses to support this change.  Namely by copying the docker-compose setup from here into our test harnesses.  

Additionally, we should not be using node-firefox-debug mode for production.  Added node-firefox-debug to docker-compose.dev.yml for dev mode. 