### PR TITLE
QEA-1247: add refresh method and exception logging to page class

### DIFF
--- a/lib/page.rb
+++ b/lib/page.rb
@@ -23,7 +23,7 @@ module Gridium
       begin
         wait.until {Driver.driver.find_element(:css, css).enabled?}
       rescue Exception => exception
-        Log.debug("page.has_css? is false because this exception was rescued: #{exception}")
+        Log.debug("[GRIDIUM::Page] has_css? is false because this exception was rescued: #{exception}")
         return false
       end
     end
@@ -33,7 +33,7 @@ module Gridium
       begin
         wait.until {Driver.driver.find_element(:xpath, xpath).enabled?}
       rescue Exception => exception
-        Log.debug("page.has_xpath? is false because this exception was rescued: #{exception}")
+        Log.debug("[GRIDIUM::Page] has_xpath? is false because this exception was rescued: #{exception}")
         return false
       end
     end
@@ -43,7 +43,7 @@ module Gridium
       begin
         wait.until {Driver.driver.find_element(:link_text, linktext).enabled?}
       rescue Exception => exception
-        Log.debug("page.has_link? is false because this exception was rescued: #{exception}")
+        Log.debug("[GRIDIUM::Page] has_link? is false because this exception was rescued: #{exception}")
         return false
       end
     end
@@ -57,7 +57,7 @@ module Gridium
       begin
         element = wait.until {Driver.html.include? text}
       rescue Exception => exception
-        Log.debug("page.has_flash? exception was rescued: #{exception}")
+        Log.debug("[GRIDIUM::Page] has_flash? exception was rescued: #{exception}")
         Log.warn("Could not find the flash message!")
       end
 
@@ -135,7 +135,7 @@ module Gridium
       begin
         button.click
       rescue Exception => exception
-        Log.debug("Button not found and this exception was rescued: #{exception} Attempting Link - speed up test by using click_link method if this works...")
+        Log.debug("[GRIDIUM::Page] Button not found and this exception was rescued: #{exception} Attempting Link - speed up test by using click_link method if this works...")
         click_link button_name, link_index: button_index
       end
     end

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -22,7 +22,8 @@ module Gridium
       wait = Selenium::WebDriver::Wait.new(:timeout => 5)
       begin
         wait.until {Driver.driver.find_element(:css, css).enabled?}
-      rescue Exception
+      rescue Exception => exception
+        Log.debug("page.has_css? is false because this exception was rescued: #{exception}")
         return false
       end
     end
@@ -31,7 +32,8 @@ module Gridium
       wait = Selenium::WebDriver::Wait.new(:timeout => 5)
       begin
         wait.until {Driver.driver.find_element(:xpath, xpath).enabled?}
-      rescue Exception
+      rescue Exception => exception
+        Log.debug("page.has_xpath? is false because this exception was rescued: #{exception}")
         return false
       end
     end
@@ -40,7 +42,8 @@ module Gridium
       wait = Selenium::WebDriver::Wait.new(:timeout => 5)
       begin
         wait.until {Driver.driver.find_element(:link_text, linktext).enabled?}
-      rescue Exception
+      rescue Exception => exception
+        Log.debug("page.has_link? is false because this exception was rescued: #{exception}")
         return false
       end
     end
@@ -53,7 +56,8 @@ module Gridium
       wait = Selenium::WebDriver::Wait.new(:timeout => 5) #5 seconds every 500ms
       begin
         element = wait.until {Driver.html.include? text}
-      rescue
+      rescue Exception => exception
+        Log.debug("page.has_flash? exception was rescued: #{exception}")
         Log.warn("Could not find the flash message!")
       end
 
@@ -130,7 +134,8 @@ module Gridium
       end
       begin
         button.click
-      rescue Exception
+      rescue Exception => exception
+        Log.debug("page.click_button exception was rescued: #{exception}")
         Log.debug("Button not found - Attempting Link - speed up test by using click_link method if this works...")
         click_link button_name, link_index: button_index
       end
@@ -139,5 +144,10 @@ module Gridium
     def check(id) #checks a checkbox
       Driver.driver.find_element(:id, id).click
     end
+  end
+
+  def refresh
+    Driver.refresh
+    self.class.new
   end
 end

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -135,8 +135,7 @@ module Gridium
       begin
         button.click
       rescue Exception => exception
-        Log.debug("page.click_button exception was rescued: #{exception}")
-        Log.debug("Button not found - Attempting Link - speed up test by using click_link method if this works...")
+        Log.debug("Button not found and this exception was rescued: #{exception} Attempting Link - speed up test by using click_link method if this works...")
         click_link button_name, link_index: button_index
       end
     end

--- a/spec/page_objects/status_codes.rb
+++ b/spec/page_objects/status_codes.rb
@@ -1,0 +1,10 @@
+class StatusCodes < Page
+
+  PAGE_NAME = '/status_codes'
+
+  def initialize
+    @wait = Selenium::WebDriver::Wait.new :timeout => Gridium.config.element_timeout
+    Log.debug("[StatusCodes] New StatusCodes Page at #{Driver.current_url} entitled #{Driver.title}. Now awaiting url to include #{PAGE_NAME}")
+    @wait.until {Driver.current_url.include? PAGE_NAME}
+  end
+end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,5 +1,6 @@
 require_relative 'spec_helper'
 # require 'pry'
+require 'page_objects/status_codes'
 
 describe Page do
   let(:test_driver) { Driver }
@@ -116,5 +117,16 @@ describe Page do
       page.click_link "Contact Us", link_index: 2
       Driver.verify_url "https://sendgrid.com/login"
     end
+  end
+
+  describe 'refresh' do
+    let(:internet_status_url) {'the-internet:9000/status_codes'}
+    it 'should return new subclass object' do
+      Driver.visit internet_status_url
+      status_code_page = StatusCodes.new
+      new_page_object = status_code_page.refresh
+      expect(new_page_object.class).to eq StatusCodes
+    end
+
   end
 end


### PR DESCRIPTION
I needed a refresh method in the base page class because lots of mako tests will make api calls then refresh the page before continuing.

I added a unit test for this.

I also saw exceptions not being logged, so I added that.