### PR TITLE
QEA-1260: move cookie methods from mako to Driver class

### DIFF
--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -273,4 +273,19 @@ class Driver
     Log.debug("Now back to Parent Frame")
   end
 
+  def self.delete_cookie(cookie)
+    Driver.driver.manage.delete_cookie(cookie)
+  end
+
+  def self.get_cookie(cookie_name)
+    Driver.driver.manage.all_cookies().each do |cookie|
+      # match cookie
+      if cookie[:name] == cookie_name
+        return cookie
+      end
+    end
+
+    return nil
+  end
+
 end


### PR DESCRIPTION
These methods were in the mako_nav class but seem better suited here in gridium's driver class.