### PR TITLE
QEA: 1108 expose selenium element methods in gridium

### DIFF
--- a/lib/element.rb
+++ b/lib/element.rb
@@ -90,6 +90,12 @@ class Element
     element.attribute(name)
   end
 
+  def css_value(name)
+    element.css_value(name)
+  end
+
+
+
   def present?
     return element.enabled?
   rescue StandardError => error
@@ -166,8 +172,13 @@ class Element
 
 
 
+
   def location
     element.location
+  end
+
+  def location_once_scrolled_into_view
+    element.location_once_scrolled_into_view
   end
 
   def hover_over

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -6,7 +6,7 @@ class Element
   attr_reader :name, :by, :locator
 
 
-  def initialize(name, by, locator, parent=nil)
+  def initialize(name, by, locator, opts = {})
     @name = name
     @by = by
     @locator = locator
@@ -19,7 +19,7 @@ class Element
     @element = nil
 
     # should always be driver unless getting an element's child
-    @parent ||= @driver
+    @parent ||= (opts[:parent] || @driver)
 
     #how long to wait between clearing an input and sending keys to it
     @text_padding_time = 0.15
@@ -268,7 +268,7 @@ class Element
   #
   def find_element(by, locator)
     Log.debug('Finding element...')
-    Element.new("Child of #{@name}", by, locator, parent=@element)
+    Element.new("Child of #{@name}", by, locator, parent: @element)
   end
 
   #
@@ -281,8 +281,7 @@ class Element
   #
   def find_elements(by, locator)
     elements = element.find_elements(by, locator)
-    gridium_elements = elements.map {|element| Element.new("Child of #{@name}", by, locator, @element)}
-    gridium_elements
+    elements.map {|_| Element.new("Child of #{@name}", by, locator, parent: @element)}
   end
 
   def save_element_screenshot

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -62,7 +62,6 @@ describe Element do
 
   describe 'child elements' do
     it '#find_element should return a gridium element' do
-      skip "unskip when this is implemented"
       Driver.visit the_internet_url
       content = Element.new("internet content", :id, "content")
       actual_header_element_class = content.find_element(:tag_name, "h1").class
@@ -71,7 +70,6 @@ describe Element do
     end
 
     it '#find_elements should return a list of gridium elements' do
-      skip "unskip when this is implemented"
       Driver.visit the_internet_url
       content = Element.new("internet content", :id, "content")
       nav_links = content.find_elements(:css, "ul > li > a")
@@ -85,7 +83,7 @@ describe Element do
     let(:test_input_page) { "http://mustadio:3000/fields" }
 
     it 'should continue to work after many attempts' do
-      (1..10).each do
+      (1..5).each do
         Driver.visit test_input_page
         (1..11).each do |i|
           expected_text = "#{i}_#{SecureRandom.uuid}"

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -6,6 +6,7 @@ describe Element do
   let(:test_element) { Element }
   let(:logger) { Log }
   let(:test_element_verification) { ElementVerification }
+  let(:the_internet_url) {'http://the-internet:5000'}
 
   before :all do
     Gridium.config.browser_source = :remote
@@ -36,8 +37,48 @@ describe Element do
       disabled = Element.new "disabled field", :css, "[id=\"input_disabled\"]"
       expect {ElementExtensions.highlight(disabled)}.not_to raise_error
     end
+  end
 
+  describe '#css_value' do
+    it 'should return a css value' do
+      Driver.visit the_internet_url
+      header = Element.new('internet header', :css, "div[id=\"content\"] > h1")
+      actual_box_sizing = header.css_value("box-sizing")
+      expected_box_sizing = 'border-box'
+      expect(actual_box_sizing).to eq expected_box_sizing
+    end
+  end
 
+  describe '#location_once_scrolled_into_view' do
+    let(:long_page_url) {the_internet_url + "/large"}
+    it 'should be different than the absolute location' do
+      Driver.visit long_page_url
+      footer = Element.new('internet footer', :id, 'page-footer')
+      absolute_location = footer.location
+      scrolled_location = footer.location_once_scrolled_into_view
+      expect(scrolled_location).not_to eq absolute_location
+    end
+  end
+
+  describe 'child elements' do
+    it '#find_element should return a gridium element' do
+      skip "unskip when this is implemented"
+      Driver.visit the_internet_url
+      content = Element.new("internet content", :id, "content")
+      actual_header_element_class = content.find_element(:tag_name, "h1").class
+      expected_header_element_class = content.class
+      expect(actual_header_element_class).to eq expected_header_element_class
+    end
+
+    it '#find_elements should return a list of gridium elements' do
+      skip "unskip when this is implemented"
+      Driver.visit the_internet_url
+      content = Element.new("internet content", :id, "content")
+      nav_links = content.find_elements(:css, "ul > li > a")
+      actual_nav_element_classes = (nav_links.map {|_| _.class}).uniq
+      expected_nav_element_classes = [content.class]
+      expect(actual_nav_element_classes).to match_array(expected_nav_element_classes)
+    end
   end
 
   describe 'text input' do


### PR DESCRIPTION
Gridium::Element will now offer methods for #css_value and #location_once_scrolled_into_view.
I did not expose #hash and #inspect, as they seemed low-level and I'm not sure they are necessary. I'm not sure what they're for really.

Preexisting methods #find_element and #find_elements will now return gridium elements instead of selenium elements. I did this by setting a parent ref in the Gridium::Element, but if there's cleaner way to do this where parent is never publically exposed I would be happy to make that change.

`rspec ./spec/element_spec.rb    `