### PR TITLE
QEA-980: implement page load strategy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,17 @@ services:
       - HUB_PORT_4444_TCP_PORT=4444
       - no_proxy=localhost
       - HUB_ENV_no_proxy=localhost
+  chrome:
+    image: sethuster/node-chrome-debug
+    ports:
+      - "5900"
+    depends_on:
+      - hub
+    environment:
+      - HUB_PORT_4444_TCP_ADDR=hub
+      - HUB_PORT_4444_TCP_PORT=4444
+      - no_proxy=localhost
+      - HUB_ENV_no_proxy=localhost
   mustadio:
     image: yetanotherlucas/mustadio
     ports:

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -31,7 +31,9 @@ class Driver
         @browser_type = Gridium.config.browser
         ##Adding support for remote browsers
         if Gridium.config.browser_source == :remote
-          @@driver = Selenium::WebDriver.for(:remote, url: Gridium.config.target_environment, desired_capabilities: Gridium.config.browser)
+          # caps = Selenium::WebDriver::Remote::Capabilities.new(:browser => Gridium.config.browser, :page_load_strategy => Gridium.config.page_load_strategy)
+          caps = Selenium::WebDriver::Remote::Capabilities.new(:browser_name => Gridium.config.browser, :browser => Gridium.config.browser, :page_load_strategy => Gridium.config.page_load_strategy)
+          @@driver = Selenium::WebDriver.for(:remote, url: Gridium.config.target_environment, desired_capabilities: caps)
           Log.debug("[Gridium::Driver] Remote Browser Requested: #{@@driver}")
           #this file detector is only used for remote drivers and is needed to upload files from test_host through Grid to browser
           @@driver.file_detector = lambda do |args|

--- a/lib/gridium.rb
+++ b/lib/gridium.rb
@@ -24,6 +24,7 @@ module Gridium
     attr_accessor :report_dir, :browser_source, :target_environment, :browser, :url, :page_load_timeout, :element_timeout, :visible_elements_only, :log_level
     attr_accessor :highlight_verifications, :highlight_duration, :screenshot_on_failure, :screenshots_to_s3, :project_name_for_s3, :subdirectory_name_for_s3
     attr_accessor :testrail
+    attr_accessor :page_load_strategy
 
     def initialize
       @report_dir = Dir.home
@@ -32,6 +33,7 @@ module Gridium
       @browser = :firefox
       @url = "about:blank"
       @page_load_timeout = 15
+      @page_load_strategy = 'normal' # none, eager, or normal (https://w3c.github.io/webdriver/webdriver-spec.html#navigation)
       @element_timeout = 15  #This needs to be changed to only look for an element after a page is done loading
       @visible_elements_only = true
       @log_level = :fatal

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -8,12 +8,6 @@ describe Element do
   let(:test_element_verification) { ElementVerification }
   let(:the_internet_url) {'http://the-internet:5000'}
 
-  before :all do
-    Gridium.config.browser_source = :remote
-    Gridium.config.target_environment = "http://hub:4444/wd/hub"
-    Gridium.config.browser = :firefox
-  end
-
   after :each do
     Driver.quit
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ Gridium.configure do |config|
   config.browser_source = :remote
   config.target_environment = "http://hub:4444/wd/hub"
   config.browser = :firefox
+  config.page_load_strategy = 'normal'
   config.url = "http://www.sendgrid.com"
   config.page_load_timeout = 15
   config.element_timeout = 15


### PR DESCRIPTION
Implemented support for page_load_strategy desired capability for remote browsers.
Added a chrome node to docker-compose for unit testing.

Deleted some unnecessary config overrides I noticed in element spec; I ran it against chrome by mistake and I noticed it still went to firefox.

```
rspec ./spec/driver_spec.rb 
rspec ./spec/element_spec.rb
```