### PR TITLE
QEA-955: Page methods that return elements will now return Gridium Elements

### DIFF
--- a/lib/page.rb
+++ b/lib/page.rb
@@ -105,7 +105,7 @@ module Gridium
     end
 
     def first(by, locator)
-      Driver.driver.find_elements(by, locator).first
+      all(by, locator).first
     end
 
     def click_on(text)

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -96,7 +96,8 @@ module Gridium
     end
 
     def all(by, locator)
-      Driver.driver.find_elements(by, locator)
+      root = Element.new("root", :tag_name, "html")
+      root.find_elements(by, locator)
     end
 
     def find(by, locator)

--- a/spec/page_objects/internet_home.rb
+++ b/spec/page_objects/internet_home.rb
@@ -1,0 +1,11 @@
+require 'gridium'
+class InternetHome < Page
+
+  PAGE_NAME = '/'
+
+  def initialize
+    @wait = Selenium::WebDriver::Wait.new :timeout => Gridium.config.element_timeout
+    Log.debug("[InternetHome] New Internet Home Page at #{Driver.current_url} entitled #{Driver.title}. Now awaiting url to include #{PAGE_NAME}")
+    @wait.until {Driver.current_url.include? PAGE_NAME}
+  end
+end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,11 +1,13 @@
 require_relative 'spec_helper'
 # require 'pry'
 require 'page_objects/status_codes'
+require 'page_objects/internet_home'
 
 describe Page do
   let(:test_driver) { Driver }
   let(:test_page) { Page }
   let(:logger) { Log }
+  let(:the_internet_url) {'http://the-internet:5000'}
 
   after :each do
     test_driver.quit
@@ -60,11 +62,13 @@ describe Page do
   end
 
   describe '#all' do
-    it 'it finds all elements' do
-      page = Page.new
-      expect(test_driver.driver).to receive(:find_elements).with(:css, '.btn-primary')
-
-      page.all(:css, '.btn-primary')
+    let(:internet_home) {InternetHome.new}
+    it '#all should return a list of gridium elements' do
+      test_driver.visit the_internet_url
+      nav_links = internet_home.all(:css, "[id=\"content\"] > ul > li > a")
+      actual_nav_element_classes = (nav_links.map {|_| _.class}).uniq
+      expected_nav_element_classes = [Element]
+      expect(actual_nav_element_classes).to match_array(expected_nav_element_classes)
     end
   end
 


### PR DESCRIPTION
The #all method will now return a list of gridium elements.
The #first method will now return a gridium element.

`rspec ./spec/page_spec.rb `