### PR TITLE
QEA-972: many logging changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ To get started using Gridium add the Gem to your automated test library.  Includ
 Gridium.configure do |config|
   config.report_dir = '/path/to/automation/project'
   config.browser_source = :local
+  config.selenium_log_level = 'OFF' #OFF, SEVERE, WARNING, INFO, DEBUG, ALL https://github.com/SeleniumHQ/selenium/wiki/Logging
   config.target_environment = "Integration"
   config.browser = :firefox
   config.url = "http://www.applicationundertest.com"
@@ -95,6 +96,8 @@ You may be saying to yourself - 'Holy Crap that's a lot of settings!'.  Yeah.  I
 
 ##### Gridium Configuration Options:  
 `config.report_dir = '/path/to/automation/project'`: This setting tells Gridium where to write reports (i.e. Log files) out to.  This could and probably will be changed at some point to eliminate some required Rspec.configuration options.  
+`config.browser_source = :local` = This to use a local or remote (with grid) webdriver
+`config.selenium_log_level = 'OFF'`: This tells gridium which level to use for Selenium's loggingPrefs, which are then logged at the debug level.
 `config.target_environment = "Stage"`: This is a simple log entry to tell remind you which environment you're testing.  
 `config.browser = :firefox`: This tells gridium which browser you will be testing.  Only firefox is working currently.  Future browsers to come.  
 `config.url = "http://www.applicationundertest.com"`: Where's the entry point for your web application?  
@@ -104,9 +107,9 @@ You may be saying to yourself - 'Holy Crap that's a lot of settings!'.  Yeah.  I
 `config.highlight_verifications = true`: Will highlight the element Gridium finds in the browser.  This makes watching tests run easier to follow, although it does slow the test execution time down.  Recommend this is turned off for automated tests running in Jenkins or headless mode.  
 `config.highlight_duration = 0.100`: How long should the element be highlighted (in milliseconds) before the action is performed on the element.  
 `config.screenshot_on_failure = false`: Take a screenshot on failure.  On or off. Obviously.  
-`config.screenshots_to_s3 = false`: This option allows users to save screenshots to an s3 bucket.  AWS S3 buckets need to be setup and configured in AWS.  Environment variables needs to be set for S3.  See environment variables section.
-`config.project_name_for_s3 = 'GRIDIUM'`: This will be appended to the filename in the front of the file. Should not contain spaces.
-`config.subdirectory_name_for_s3 = 'TEST NAME'`: This will be the directory in S3 root to store the files.  Used primarily to differentiate between project artifacts in the same s3 bucket.
+`config.screenshots_to_s3 = false`: This option allows users to save screenshots to an s3 bucket.  AWS S3 buckets need to be setup and configured in AWS.  Environment variables needs to be set for S3.  See environment variables section.  
+`config.project_name_for_s3 = 'GRIDIUM'`: This will be appended to the filename in the front of the file. Should not contain spaces.  
+`config.subdirectory_name_for_s3 = 'TEST NAME'`: This will be the directory in S3 root to store the files.  Used primarily to differentiate between project artifacts in the same s3 bucket.  
 `config.testrail = true`: This to enable TestRail integration. With this turned on, test results will be updated in your TestRail instance.
 
 ##### Environment variables
@@ -202,6 +205,16 @@ Notice that to use Gridium functionality, Gridium needs to be included at the to
 Page object are made up of Elements.  The methods on the page object tells the test how interact with the elements.  For example, the Login method shown in the example sets the Username field, the password field and then clicks the login button.  
 
 This action will return a new page, that our test is setup to handle.
+
+##Logging
+A log file will always be created with at least one line, showing whichever config.log_level is set to.
+This file can be found in `spec_reports/spec_results_{timestamp}/{timestamp}_spec.log` alongside any screenshots taken.
+Any log statements using a level equal or lower than config.log_level will be logged.
+
+#### Selenium Logging
+To open the firehose to selenium's logging (https://github.com/SeleniumHQ/selenium/wiki/Logging)
+1. Set `config.selenium_log_level = 'ALL'` to  set each type of selenium logging (browser, driver, client, server) to 'ALL'  
+2. Set `config.log_level = :debug` to have them picked up by gridium's logger.
 
 ## Elements
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ $errors_total = 0
 Spec_data.load_suite_state
 Spec_data.load_spec_state
 ```
-##Saving screenshots to S3
+## Saving screenshots to S3
 
 S3 support is available for persisting screenshots online. This is especially helpful when running tests in CI and/or Docker environments.
 
@@ -206,7 +206,7 @@ Page object are made up of Elements.  The methods on the page object tells the t
 
 This action will return a new page, that our test is setup to handle.
 
-##Logging
+## Logging
 A log file will always be created with at least one line, showing whichever config.log_level is set to.
 This file can be found in `spec_reports/spec_results_{timestamp}/{timestamp}_spec.log` alongside any screenshots taken.
 Any log statements using a level equal or lower than config.log_level will be logged.

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -373,7 +373,7 @@ class Element
 
   def stale?
     return true if @element.nil?
-    @element.disabled?
+    @element.displayed?
   rescue StandardError => error
     Log.debug("[GRIDIUM::Element] element.stale? is true because this error was rescued: #{error}")
     Log.warn("[GRIDIUM::Element] Stale element detected.... #{self.to_s}")

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -35,7 +35,7 @@ class Element
       if Gridium.config.visible_elements_only
         wait.until { @element = displayed_element }
       else
-        wait.until { @element = @parent.find_element(@by, @locator); Log.debug("Finding element #{self}..."); @element.enabled? }
+        wait.until { @element = @parent.find_element(@by, @locator); Log.debug("[GRIDIUM::Element] Finding element #{self}..."); @element.enabled? }
       end
 
     end
@@ -57,14 +57,14 @@ class Element
         end
       end
       if found_element.nil?
-        Log.debug "found #{elements.length} element(s) via #{@by} and #{@locator} and 0 are displayed"
+        Log.debug "[GRIDIUM::Element] found #{elements.length} element(s) via #{@by} and #{@locator} and 0 are displayed"
       end
     rescue StandardError => error
-      Log.debug("element.displayed_element rescued: #{error}")
+      Log.debug("[GRIDIUM::Element] element.displayed_element rescued: #{error}")
       if found_element
-        Log.warn("An element was found, but it was not displayed on the page. Gridium.config.visible_elements_only set to: #{Gridium.config.visible_elements_only} Element: #{self.to_s}")
+        Log.warn("[GRIDIUM::Element] An element was found, but it was not displayed on the page. Gridium.config.visible_elements_only set to: #{Gridium.config.visible_elements_only} Element: #{self.to_s}")
       else
-        Log.warn("Could not find Element: #{self.to_s}")
+        Log.warn("[GRIDIUM::Element] Could not find Element: #{self.to_s}")
       end
     end
 
@@ -77,14 +77,14 @@ class Element
 
   # soft failure, will not kill test immediately
   def verify(timeout: nil)
-    Log.debug('Verifying new element...')
+    Log.debug('[GRIDIUM::Element] Verifying new element...')
     timeout = Gridium.config.element_timeout if timeout.nil?
     ElementVerification.new(self, timeout)
   end
 
   # hard failure, will kill test immediately
   def wait_until(timeout: nil)
-    Log.debug('Waiting for new element...')
+    Log.debug('[GRIDIUM::Element] Waiting for new element...')
     timeout = Gridium.config.element_timeout if timeout.nil?
     ElementVerification.new(self, timeout, fail_test: true)
   end
@@ -102,14 +102,14 @@ class Element
   def present?
     return element.enabled?
   rescue StandardError => error
-    Log.debug("element.present? is false because this error was rescued: #{error}")
+    Log.debug("[GRIDIUM::Element] element.present? is false because this error was rescued: #{error}")
     return false
   end
 
   def displayed?
     return element.displayed?
   rescue StandardError => error
-    Log.debug("element.displayed? is false because this error was rescued: #{error}")
+    Log.debug("[GRIDIUM::Element] element.displayed? is false because this error was rescued: #{error}")
     return false
   end
 
@@ -198,7 +198,7 @@ class Element
   end
 
   def hover_over
-    Log.debug("Hovering over element (#{self.to_s})...")
+    Log.debug("[GRIDIUM::Element] Hovering over element (#{self.to_s})...")
     # @driver.mouse.move_to(element)            # Note: Doesn't work with Selenium 2.42 bindings for Firefox v31
     # @driver.action.move_to(element).perform
     # @driver.mouse_over(@locator)
@@ -206,28 +206,28 @@ class Element
       $verification_passes += 1
       ElementExtensions.hover_over(self) # Javascript workaround to above issue
     else
-      Log.error('Cannot hover over element.  Element is not present.')
+      Log.error('[GRIDIUM::Element] Cannot hover over element.  Element is not present.')
     end
   end
 
   def hover_away
-    Log.debug("Hovering away from element (#{self.to_s})...")
+    Log.debug("[GRIDIUM::Element] Hovering away from element (#{self.to_s})...")
     if element.enabled?
       $verification_passes += 1
       ElementExtensions.hover_away(self) # Javascript workaround to above issue
     else
-      Log.error('Cannot hover away from element.  Element is not present.')
+      Log.error('[GRIDIUM::Element] Cannot hover away from element.  Element is not present.')
     end
   end
 
   # Raw webdriver mouse over
   def mouse_over
-    Log.debug("Triggering mouse over for (#{self.to_s})...")
+    Log.debug("[GRIDIUM::Element] Triggering mouse over for (#{self.to_s})...")
     if element.enabled?
       $verification_passes += 1
       ElementExtensions.mouse_over(self)
     else
-      Log.error('Cannot mouse over.  Element is not present.')
+      Log.error('[GRIDIUM::Element] Cannot mouse over.  Element is not present.')
     end
   end
 
@@ -236,17 +236,17 @@ class Element
       $verification_passes += 1
       ElementExtensions.scroll_to(self)
     else
-      Log.error('Cannot scroll element into view.  Element is not present.')
+      Log.error('[GRIDIUM::Element] Cannot scroll element into view.  Element is not present.')
     end
   end
 
   def trigger_onblur
-    Log.debug("Triggering onblur for (#{self.to_s})...")
+    Log.debug("[GRIDIUM::Element] Triggering onblur for (#{self.to_s})...")
     if element.enabled?
       $verification_passes += 1
       ElementExtensions.trigger_onblur(self)
     else
-      Log.error('Cannot trigger onblur.  Element is not present.')
+      Log.error('[GRIDIUM::Element] Cannot trigger onblur.  Element is not present.')
     end
   end
 
@@ -280,7 +280,7 @@ class Element
   # @return [Element] element
   #
   def find_element(by, locator)
-    Log.debug('Finding element...')
+    Log.debug('[GRIDIUM::Element] Finding element...')
     Element.new("Child of #{@name}", by, locator, parent: @element)
   end
 
@@ -298,7 +298,7 @@ class Element
   end
 
   def save_element_screenshot
-    Log.debug ("Capturing screenshot of element...")
+    Log.debug ("[GRIDIUM::Element] Capturing screenshot of element...")
     self.scroll_into_view
 
     timestamp = Time.now.strftime("%Y_%m_%d__%H_%M_%S")
@@ -324,28 +324,28 @@ class Element
   def compare_element_screenshot(base_image_path)
     #Returns TRUE if there are no differences, FALSE if there are
     begin
-      Log.debug("Loading Images for Comparison...")
+      Log.debug("[GRIDIUM::Element] Loading Images for Comparison...")
       images = [
           ChunkyPNG::Image.from_file(base_image_path),
           ChunkyPNG::Image.from_file(@element_screenshot)
       ]
       #used to store image x,y diff
       diff = []
-      Log.debug("Comparing Images...")
+      Log.debug("[GRIDIUM::Element] Comparing Images...")
       images.first.height.times do |y|
         images.first.row(y).each_with_index do |pixel, x|
           diff << [x,y] unless pixel == images.last[x,y]
         end
       end
 
-      Log.debug("Pixels total:    #{images.first.pixels.length}")
-      Log.debug("Pixels changed:  #{diff.length}")
-      Log.debug("Pixels changed:  #{(diff.length.to_f / images.first.pixels.length) * 100}%")
+      Log.debug("[GRIDIUM::Element] Pixels total:    #{images.first.pixels.length}")
+      Log.debug("[GRIDIUM::Element] Pixels changed:  #{diff.length}")
+      Log.debug("[GRIDIUM::Element] Pixels changed:  #{(diff.length.to_f / images.first.pixels.length) * 100}%")
 
       x, y = diff.map{|xy| xy[0]}, diff.map{|xy| xy[1]}
 
       if x.any? && y.any?
-        Log.debug("Differences Detected! Writing Diff Image...")
+        Log.debug("[GRIDIUM::Element] Differences Detected! Writing Diff Image...")
         name = self.name.gsub(' ', '_')
         #timestamp = Time.now.strftime("%Y_%m_%d__%H_%M_%S")
         element_screenshot_path = File.join($current_run_dir, "#{name}__diff_.png")
@@ -361,7 +361,7 @@ class Element
   end
 
   def method_missing(method_sym, *arguments, &block)
-    Log.debug("called #{method_sym} on element #{@locator} by #{@by_type}")
+    Log.debug("[GRIDIUM::Element] called #{method_sym} on element #{@locator} by #{@by_type}")
     if @element.respond_to?(method_sym)
       @element.method(method_sym).call(*arguments, &block)
     else
@@ -375,8 +375,8 @@ class Element
     return true if @element.nil?
     @element.disabled?
   rescue StandardError => error
-    Log.debug("element.stale? is true because this error was rescued: #{error}")
-    Log.warn("Stale element detected.... #{self.to_s}")
+    Log.debug("[GRIDIUM::Element] element.stale? is true because this error was rescued: #{error}")
+    Log.warn("[GRIDIUM::Element] Stale element detected.... #{self.to_s}")
     return true
   end
 
@@ -385,10 +385,10 @@ class Element
   #
 
   def _stomp_input_text(*args)
-    Log.debug("Clearing \"#{value}\" from element: (#{self})")
+    Log.debug("[GRIDIUM::Element] Clearing \"#{value}\" from element: (#{self})")
     element.clear
     sleep @text_padding_time
-    Log.debug("Typing: #{args} into element: (#{self}).")
+    Log.debug("[GRIDIUM::Element] Typing: #{args} into element: (#{self}).")
     element.send_keys(*args)
     sleep @text_padding_time
   end
@@ -400,7 +400,7 @@ class Element
   #
 
   def field_empty_afterward?(*args)
-    Log.debug("Checking the field after sending #{args}, to see if it's empty")
+    Log.debug("[GRIDIUM::Element] Checking the field after sending #{args}, to see if it's empty")
     check_again = (has_characters? *args and no_symbols? *args)
     field_is_empty_but_should_not_be = (check_again and field_empty?)
     if field_is_empty_but_should_not_be

--- a/lib/element_extensions.rb
+++ b/lib/element_extensions.rb
@@ -2,7 +2,7 @@ include Gridium
 
 class Gridium::ElementExtensions
   def self.highlight(element)
-    Log.debug("Highlighting element...")
+    Log.debug("[GRIDIUM::ElementExtensions] Highlighting element...")
     original_border = Driver.execute_script("return arguments[0].style.border", element.element)
     original_background = Driver.execute_script("return arguments[0].style.backgroundColor", element.element)
     Driver.execute_script("arguments[0].style.border='3px solid lime'; return;", element.element)
@@ -13,7 +13,7 @@ class Gridium::ElementExtensions
   end
 
   def self.scroll_to(element)
-    Log.debug("Scrolling element into view...")
+    Log.debug("[GRIDIUM::ElementExtensions] Scrolling element into view...")
     Driver.execute_script("arguments[0].scrollIntoView(); return;", element.element)
     sleep 1
   end

--- a/lib/element_verification.rb
+++ b/lib/element_verification.rb
@@ -25,7 +25,7 @@ class Gridium::ElementVerification
     if @element.present?
       $verification_passes += 1
     else
-      Log.error("Cannot determine element text.  Element is not present.")
+      Log.error("[GRIDIUM::ElementVerification] Cannot determine element text.  Element is not present.")
     end
 
     if should_have_text
@@ -41,11 +41,11 @@ class Gridium::ElementVerification
       wait.until do
         element_contains_text = element_text.eql?(text)
         if should_have_text && element_contains_text
-          Log.debug("Confirming text (#{text}) is within element...")
+          Log.debug("[GRIDIUM::ElementVerification] Confirming text (#{text}) is within element...")
           ElementExtensions.highlight(@element) if Gridium.config.highlight_verifications
           log_success(pass_message)
         elsif !should_have_text && !element_contains_text
-          Log.debug("Confirming text (#{text}) is NOT within element...")
+          Log.debug("[GRIDIUM::ElementVerification] Confirming text (#{text}) is NOT within element...")
           ElementExtensions.highlight(@element) if Gridium.config.highlight_verifications
           log_success(pass_message)
         else
@@ -78,7 +78,7 @@ class Gridium::ElementVerification
           log_success(pass_message)
           return @element
         elsif !element_is_displayed && !should_be_visible
-          Log.debug("Confirming element is NOT visible...")
+          Log.debug("[GRIDIUM::ElementVerification] Confirming element is NOT visible...")
           log_success(pass_message)
         else
           log_issue(fail_message)
@@ -110,7 +110,7 @@ class Gridium::ElementVerification
           log_success(pass_message)
           return @element
         elsif !element_is_present && !should_be_present
-          Log.debug("Confirming element is NOT present...")
+          Log.debug("[GRIDIUM::ElementVerification] Confirming element is NOT present...")
           log_success(pass_message)
         else
           log_issue(fail_message)
@@ -145,17 +145,17 @@ class Gridium::ElementVerification
 
   def log_issue(message)
     if @fail_test
-      Log.error("#{message} ['#{@element.name}' (By:(#{@element.by} => '#{@element.locator}'))].")
+      Log.error("[GRIDIUM::ElementVerification] #{message} ['#{@element.name}' (By:(#{@element.by} => '#{@element.locator}'))].")
       $fail_test_instantly = true
       Kernel.fail(message)
     else
-      Log.error("#{message} ['#{@element.name}' (By:(#{@element.by} => '#{@element.locator}'))].")
+      Log.error("[GRIDIUM::ElementVerification] #{message} ['#{@element.name}' (By:(#{@element.by} => '#{@element.locator}'))].")
       $fail_test_at_end = true
     end
   end
 
   def log_success(pass_message)
     $verification_passes += 1
-    Log.debug("Verified: '#{@element.name}' (By:(#{@element.by} => '#{@element.locator}')) #{pass_message}")
+    Log.debug("[GRIDIUM::ElementVerification] Verified: '#{@element.name}' (By:(#{@element.by} => '#{@element.locator}')) #{pass_message}")
   end
 end

--- a/lib/gridium.rb
+++ b/lib/gridium.rb
@@ -23,13 +23,14 @@ module Gridium
   class Config
     attr_accessor :report_dir, :browser_source, :target_environment, :browser, :url, :page_load_timeout, :element_timeout, :visible_elements_only, :log_level
     attr_accessor :highlight_verifications, :highlight_duration, :screenshot_on_failure, :screenshots_to_s3, :project_name_for_s3, :subdirectory_name_for_s3
-    attr_accessor :testrail
+    attr_accessor :testrail, :selenium_log_level
 
     def initialize
       @report_dir = Dir.home
       @browser_source = :local  #if browser source is set to remote, target environment needs to be set properly
+      @selenium_log_level = 'OFF' #OFF, SEVERE, WARNING, INFO, DEBUG, ALL https://github.com/SeleniumHQ/selenium/wiki/Logging
       @target_environment = "localhost"
-      @browser = :firefox
+      @browser = :chrome
       @url = "about:blank"
       @page_load_timeout = 15
       @element_timeout = 15  #This needs to be changed to only look for an element after a page is done loading

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -14,7 +14,7 @@ module Gridium
       if asserted_element.eql? nil
         fail("Could not find element on page with locator #{locator} using #{by}")
       else
-        Log.info("Asserted Element present with locator #{locator} using #{by}")
+        Log.info("[GRIDIUM::Page] Asserted Element present with locator #{locator} using #{by}")
       end
     end
 
@@ -58,7 +58,7 @@ module Gridium
         element = wait.until {Driver.html.include? text}
       rescue Exception => exception
         Log.debug("[GRIDIUM::Page] has_flash? exception was rescued: #{exception}")
-        Log.warn("Could not find the flash message!")
+        Log.warn("[GRIDIUM::Page] Could not find the flash message!")
       end
 
       if element

--- a/lib/spec_data.rb
+++ b/lib/spec_data.rb
@@ -29,29 +29,29 @@ class SpecData
 
   def self.determine_spec_result
     if execution_warnings.empty?
-      Log.info("No warnings detected during test run.")
+      Log.info("[GRIDIUM::SpecData] No warnings detected during test run.")
     else
-      Log.info("Warnings detected during test run: (#{execution_warnings.length} total).")
+      Log.info("[GRIDIUM::SpecData]Warnings detected during test run: (#{execution_warnings.length} total).")
       msg = "Warning detected during test execution:"
       execution_warnings.each { |error_message| msg << "\n\t" + error_message }
     end
 
     if verification_errors.empty?
-      Log.info("No errors detected during test run.")
+      Log.info("[GRIDIUM::SpecData]No errors detected during test run.")
     else
-      Log.info("Errors detected during test run: (#{verification_errors.length} total).")
+      Log.info("[GRIDIUM::SpecData]Errors detected during test run: (#{verification_errors.length} total).")
       msg = "TEST FAILURE: Errors detected during test execution:"
       verification_errors.each { |error_message| msg << "\n\t" + error_message }
     end
 
     if $fail_test_instantly
-      Log.info("TEST FAILED - CRITICAL ERROR DETECTED")
+      Log.info("[GRIDIUM::SpecData]TEST FAILED - CRITICAL ERROR DETECTED")
       Kernel.fail("TEST FAILED - CRITICAL ERROR DETECTED\n")
     elsif $fail_test_at_end
-      Log.info("TEST FAILED - VERIFICATION ERRORS DETECTED")
+      Log.info("[GRIDIUM::SpecData]TEST FAILED - VERIFICATION ERRORS DETECTED")
       Kernel.fail("TEST FAILED - VERIFICATION ERRORS DETECTED\n")
     else
-      Log.info("TEST PASSED\n")
+      Log.info("[GRIDIUM::SpecData]TEST PASSED\n")
     end
   end
 

--- a/lib/testrail.rb
+++ b/lib/testrail.rb
@@ -88,7 +88,7 @@ module Gridium
           r = _send_request('POST', "#{@url}add_results_for_cases/#{@run_info[:id]}", {results: @tc_results})
           Log.debug("[GRIDIUM::TestRail] ADD RESULTS: #{r}")
           sleep 0.25
-          Log.debug("#{r.class}")
+          Log.debug("[GRIDIUM::TestRail] #{r.class}")
           if r.is_a?(Hash)
             r = _send_request('POST', "#{@url}update_run/#{@run_info[:id]}", {:name => "ER:#{@run_info[:name]}", :description => "#{@run_info[:desc]}\nThe following was returned when adding cases: #{r}"})
             Log.warn("[GRIDIUM::TestRail] ERROR: #{r}")

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -59,6 +59,8 @@ describe Driver do
       it 'should raise script timeout error' do
         too_long = 1 + instant_timeout
         slow_url = "#{mustadio}/slow?seconds=#{too_long}"
+        #TODO seek a workaround to this issue of 'cannot determine loading status' instakilling the browser
+        # this looks like a bug in chrome https://bugs.chromium.org/p/chromedriver/issues/detail?id=402
         # expect {test_driver.send(:visit, slow_url)}.to raise_error error = Selenium::WebDriver::Error::ScriptTimeoutError
         expect {test_driver.send(:visit, slow_url)}.to raise_error
       end
@@ -368,7 +370,42 @@ describe Driver do
 
   end
 
+  describe 'selenium logging' do
+
+    after :each do
+      test_driver.quit
+    end
+
+    it 'should log nothing when level is OFF' do
+      expected_logs = {}
+      actual_logs = {}
+      gridium_config.selenium_log_level = 'OFF'
+      #force browser logging to have a value
+      test_driver.visit("http://localhost:8080")
+      test_driver.driver.manage.logs.available_types.each do |log_type|
+        actual_logs[log_type] = test_driver.driver.manage.logs.get(log_type)
+        expected_logs[log_type] = []
+      end
+      expect(actual_logs).to eq expected_logs
+    end
+
+    it 'should log something when level is ALL' do
+      expected_logs = {}
+      actual_logs = {}
+      gridium_config.selenium_log_level = 'ALL'
+      #force browser logging to have a value
+      test_driver.visit("http://localhost:8080")
+      test_driver.driver.manage.logs.available_types.each do |log_type|
+        actual_logs[log_type] = test_driver.driver.manage.logs.get(log_type)
+        expected_logs[log_type] = []
+      end
+      expect(actual_logs.values).not_to be_empty
+    end
+  end
+
+
   def create_new_element(name, by, locator)
     Element.new(name, by, locator)
   end
+
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -320,7 +320,7 @@ describe Driver do
       begin
         get_started_btn.click
       rescue
-        expect(test_spec_data.execution_warnings.include?("Stale element detected.... 'Plans and Pricing' (By:css => '#home-pricing-cta')")).to eq true
+        expect(test_spec_data.execution_warnings.include?("[GRIDIUM::Element] Stale element detected.... 'Plans and Pricing' (By:css => '#home-pricing-cta')")).to eq true
       end
     end
 

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -82,6 +82,10 @@ describe Element do
   describe 'text input' do
     let(:test_input_page) { "http://mustadio:3000/fields" }
 
+    after :each do
+      Driver.quit
+    end
+
     it 'should continue to work after many attempts' do
       (1..5).each do
         Driver.visit test_input_page
@@ -93,7 +97,6 @@ describe Element do
         end
         submit = Element.new "submit button", :css, "[id=\"input_submit\"]"
         submit.click
-        Driver.quit
       end
     end
 
@@ -130,12 +133,9 @@ describe Element do
       expected_selector = "[id=\"input_1\"]"
       this_one = Element.new expected_selector, :css, expected_selector
       original_text = this_one.value
-      puts "original_text is #{original_text}"
       text_to_append = "#{SecureRandom.uuid}"
-      puts "text to append is #{text_to_append}"
       this_one.append_keys text_to_append
       new_text = this_one.value
-      puts "new_text is #{new_text}"
       expect(new_text).to eq (original_text + text_to_append)
     end
 

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -78,7 +78,7 @@ describe Page do
 
       test_page.assert_selector('by', 'locator')
 
-      expect(logger).to have_received(:info).with('Asserted Element present with locator locator using by')
+      expect(logger).to have_received(:info).with('[GRIDIUM::Page] Asserted Element present with locator locator using by')
     end
   end
 


### PR DESCRIPTION
The jira story is for a lot of logging changes.
Might be easier to address the changes in context of the acceptance critieria:

| Criteria | Implementation |
| --- | --- |
| 0. Standardize log message format across log levels. All log messages should contain similar information | Prefixing [MODULE::CLASS] in front of log messages. |
| 1. Large log messages (> 5 lines) need to be written to disk | AFAIK the only way to not get a log file on disk is to set the log level higher than any logging; this should be free already. |
| 2. Connection logging to selenium before calls and connections | call _log_shart method each time before accessing  webdriver |
| 3. Connection logging responses from selenium after calls and connections. | call _log_shart method in quit method to get the last logs. |

To turn on the selenium logging, set this to something other than the default of 'OFF'
`config.selenium_log_level = 'OFF' #OFF, SEVERE, WARNING, INFO, DEBUG, ALL https://github.com/SeleniumHQ/selenium/wiki/Logging`

Ran everything afterward:
`rake spec`

testrail_spec was already failing for me.

I supose _log_shart is not a good name, happy to hear suggestions.