### PR TITLE
QEA-1524: Handle NoSuchDriverError on quit

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,8 +220,8 @@ To open the firehose to selenium's logging (https://github.com/SeleniumHQ/seleni
 
 ## Testing with docker
 Gridium's unit tests are run in docker using selenium grid and some helper images:
-* gprestes/the-internet
-* yetanotherlucas/mustadio
+* [gprestes/the-internet](https://hub.docker.com/r/gprestes/the-internet/)
+* [yetanotherlucas/mustadio](https://hub.docker.com/r/yetanotherlucas/mustadio/)
 
 The bin folder contains helper scripts to setup and teardown the docker containers:
 * `bin/pull`: Use this to pull the latest docker images prior to starting. 

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -25,10 +25,6 @@ class Driver
     end
   end
 
-  def self.raw_driver
-    @@driver
-  end
-
   def self.driver
     begin
       unless @@driver
@@ -333,6 +329,12 @@ class Driver
   def self.delete_all_cookies
     Log.debug("[Gridium::Driver] Deleting all cookies")
     Driver.driver.manage.delete_all_cookies
+  end
+
+  private
+
+  def self.raw_driver
+    @@driver
   end
 
 end

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -25,6 +25,10 @@ class Driver
     end
   end
 
+  def self.raw_driver
+    @@driver
+  end
+
   def self.driver
     begin
       unless @@driver
@@ -34,6 +38,7 @@ class Driver
         if Gridium.config.browser_source == :remote
           @@driver = Selenium::WebDriver.for(:remote, url: Gridium.config.target_environment, desired_capabilities: _set_capabilities())
           Log.debug("[Gridium::Driver] Remote Browser Requested: #{@@driver}")
+
           #this file detector is only used for remote drivers and is needed to upload files from test_host through Grid to browser
           @@driver.file_detector = lambda do |args|
             str = args.first.to_s

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -129,10 +129,16 @@ class Driver
 
   def self.quit
     if @@driver
-      _log_shart #push out the last logs
-      Log.debug('[Gridium::Driver] Shutting down web driver...')
-      @@driver.quit
-      @@driver = nil
+      begin
+        _log_shart #push out the last logs
+        Log.debug('[Gridium::Driver] Shutting down web driver...')
+        @@driver.quit
+      rescue Selenium::WebDriver::Error::NoSuchDriverError => e
+        Log.debug("[Gridium::Driver] #{e.backtrace.inspect}")
+        Log.error("[Gridium::Driver] Failed to shutdown webdriver: #{e.message}")
+      ensure
+        @@driver = nil
+      end
     end
   end
 

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 require 'page_objects/cookie_page'
-# require 'pry'
 
 describe Driver do
   let(:gridium_config) { Gridium.config }
@@ -22,6 +21,32 @@ describe Driver do
 
   after :each do
     test_driver.quit
+  end
+
+  describe '#quit' do
+    it 'cleans up the session and resets driver to nil' do
+      test_driver.quit
+      expect(test_driver.raw_driver).to be_nil
+    end
+
+    context 'when driver session is borked' do
+      it 'gracefully handles NoSuchDriverError' do
+        expect(test_driver.driver).to receive(:quit).and_raise(Selenium::WebDriver::Error::NoSuchDriverError)
+        expect {test_driver.quit}.not_to raise_error
+      end
+
+      it 'sets the driver to nil' do
+        expect(test_driver.driver).to receive(:quit).and_raise(Selenium::WebDriver::Error::NoSuchDriverError)
+        test_driver.quit
+        expect(test_driver.raw_driver).to be_nil
+      end
+
+      it 'logs the failure' do
+        fail_msg = /Failed to shutdown webdriver: Selenium::WebDriver::Error::NoSuchDriverError/
+        expect(test_driver.driver).to receive(:quit).and_raise(Selenium::WebDriver::Error::NoSuchDriverError)
+        expect(test_driver.quit).to include fail_msg
+      end
+    end
   end
 
   describe '#reset' do

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -26,24 +26,25 @@ describe Driver do
   describe '#quit' do
     it 'cleans up the session and resets driver to nil' do
       test_driver.quit
-      expect(test_driver.raw_driver).to be_nil
+      expect(test_driver.send(:raw_driver)).to be_nil
     end
 
     context 'when driver session is borked' do
-      it 'gracefully handles NoSuchDriverError' do
+      before :example do
         expect(test_driver.driver).to receive(:quit).and_raise(Selenium::WebDriver::Error::NoSuchDriverError)
+      end
+
+      it 'gracefully handles NoSuchDriverError' do
         expect {test_driver.quit}.not_to raise_error
       end
 
       it 'sets the driver to nil' do
-        expect(test_driver.driver).to receive(:quit).and_raise(Selenium::WebDriver::Error::NoSuchDriverError)
         test_driver.quit
-        expect(test_driver.raw_driver).to be_nil
+        expect(test_driver.send(:raw_driver)).to be_nil
       end
 
       it 'logs the failure' do
         fail_msg = /Failed to shutdown webdriver: Selenium::WebDriver::Error::NoSuchDriverError/
-        expect(test_driver.driver).to receive(:quit).and_raise(Selenium::WebDriver::Error::NoSuchDriverError)
         expect(test_driver.quit).to include fail_msg
       end
     end


### PR DESCRIPTION
```bash
  1) Sender Management UI Test Basic Functionality:  CreateSender: Verify Copy
     Failure/Error: Driver.quit

     Selenium::WebDriver::Error::NoSuchDriverError:
       Build info: version: '3.1.0', revision: '86a5d70', time: '2017-02-16 07:57:44 -0800'
       System info: host: '4390bbdabbef', ip: '172.18.0.15', os.name: 'Linux', os.arch: 'amd64', os.version: '3.10.0-327.el7.x86_64', java.version: '1.8.0_121'
       Driver info: driver.version: unknown (org.openqa.selenium.NoSuchSessionException)
```