### PR TITLE
QEA-925 expose cookie methods in gridium driver

### DIFF
--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -4,7 +4,6 @@ require 'spec_data'
 
 class Driver
 
-  # alias_method :cookie_named, :get_cookie
   @@driver = nil
 
   def self.reset

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -3,6 +3,8 @@ require 'uri'
 require 'spec_data'
 
 class Driver
+
+  alias_method :cookie_named, :get_cookie
   @@driver = nil
 
   def self.reset
@@ -298,19 +300,29 @@ class Driver
     Log.debug("[Gridium::Driver] Now back to Parent Frame")
   end
 
+  def self.add_cookie(cookie)
+    Log.debug("[Gridium::Driver] Adding cookie named #{cookie[:name]}")
+    Driver.driver.manage.add_cookie(cookie)
+  end
+
   def self.delete_cookie(cookie)
+    Log.debug("[Gridium::Driver] Deleting cookie named #{cookie[:name]}")
     Driver.driver.manage.delete_cookie(cookie)
   end
 
   def self.get_cookie(cookie_name)
-    Driver.driver.manage.all_cookies().each do |cookie|
-      # match cookie
-      if cookie[:name] == cookie_name
-        return cookie
-      end
-    end
+    Log.debug("[Gridium::Driver] Getting cookie named #{cookie[:name]}")
+    Driver.driver.manage.cookie_named(cookie_name)
+  end
 
-    return nil
+  def self.all_cookies
+    Log.debug("[Gridium::Driver] Getting all cookies")
+    Driver.driver.manage.all_cookies
+  end
+
+  def self.delete_all_cookies
+    Log.debug("[Gridium::Driver] Deleting all cookies")
+    Driver.driver.manage.delete_all_cookies
   end
 
 end

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -4,7 +4,7 @@ require 'spec_data'
 
 class Driver
 
-  alias_method :cookie_named, :get_cookie
+  # alias_method :cookie_named, :get_cookie
   @@driver = nil
 
   def self.reset
@@ -305,13 +305,13 @@ class Driver
     Driver.driver.manage.add_cookie(cookie)
   end
 
-  def self.delete_cookie(cookie)
-    Log.debug("[Gridium::Driver] Deleting cookie named #{cookie[:name]}")
-    Driver.driver.manage.delete_cookie(cookie)
+  def self.delete_cookie(cookie_name)
+    Log.debug("[Gridium::Driver] Deleting cookie named #{cookie_name}")
+    Driver.driver.manage.delete_cookie(cookie_name)
   end
 
   def self.get_cookie(cookie_name)
-    Log.debug("[Gridium::Driver] Getting cookie named #{cookie[:name]}")
+    Log.debug("[Gridium::Driver] Getting cookie named #{cookie_name}")
     Driver.driver.manage.cookie_named(cookie_name)
   end
 

--- a/spec/page_objects/cookie_page.rb
+++ b/spec/page_objects/cookie_page.rb
@@ -1,0 +1,30 @@
+class CookiePage < Page
+
+  PAGE_NAME = '/cookies'
+
+  def initialize
+    @wait = Selenium::WebDriver::Wait.new :timeout => Gridium.config.element_timeout
+    Log.debug("[CookiePage] New CookiePage Page at #{Driver.current_url} entitled #{Driver.title}. Now awaiting url to include #{PAGE_NAME}")
+    @wait.until {Driver.current_url.include? PAGE_NAME}
+  end
+
+  def refresh
+    Driver.refresh
+    self.class.new
+  end
+
+  def get_cookie(cookie_name)
+    cookie_value = Element.new("#{cookie_name} cookie row", :css, "tr[id=\"#{cookie_name}\"] [role=\"value\"]").text
+    {:name => cookie_name, :value => cookie_value}
+  end
+
+  def get_all_cookies
+    rows = Driver.driver.find_elements(:tag_name => "tr")
+    cookies = rows.map do |x|
+      cookie_name = x.find_element(:css => "[role=\"name\"]").text
+      cookie_value = x.find_element(:css => "[role=\"value\"]").text
+      {:name => cookie_name, :value => cookie_value}
+    end
+    cookies
+  end
+end


### PR DESCRIPTION
All webdriver cookie methods are now exposed by gridium driver. cookie_named was already renamed as get_cookie so keeping that for backward compatibility.
all_cookies -> all_cookies
cookie_named -> get_cookie
add_cookie -> add_cookie
delete_cookie -> delete_cookie
delete_all_cookies -> delete_all_cookies

unit tests here:
`rspec ./spec/driver_spec.rb -e "cookies"`