### PR TITLE
QEA-1634: Explicit waits

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -7,8 +7,7 @@ main(){
       docker exec $(docker-compose ps -q gridium) bundle install;
       ;;
     -d) #start in development mode
-      ${BUILD_NUMBER:=dev}
-      export BUILD_NUMBER
+      export BUILD_NUMBER=${BUILD_NUMBER:=dev}
       docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
       docker exec $(docker-compose ps -q gridium) bundle install;
       ;;

--- a/lib/driver.rb
+++ b/lib/driver.rb
@@ -10,7 +10,7 @@ class Driver
     Log.debug("[Gridium::Driver] Driver.reset: #{@@driver}")
     driver.manage.delete_all_cookies
     driver.manage.timeouts.page_load = Gridium.config.page_load_timeout
-    driver.manage.timeouts.implicit_wait = Gridium.config.element_timeout
+    driver.manage.timeouts.implicit_wait = 0 # always use explicit waits!
 
     # Ensure the browser is maximized to maximize visibility of element
     # Ensure the browser is maximized to maximize visibility of element

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -29,9 +29,11 @@ class Element
     "'#{@name}' (By:#{@by} => '#{@locator}')"
   end
 
-  def element
+  def element(opts = {})
+    timeout = opts[:timeout].nil? ? Gridium.config.element_timeout : opts[:timeout]
+
     if stale?
-      wait = Selenium::WebDriver::Wait.new :timeout => Gridium.config.element_timeout, :interval => 1
+      wait = Selenium::WebDriver::Wait.new :timeout => timeout, :interval => 1
       if Gridium.config.visible_elements_only
         wait.until { @element = displayed_element }
       else

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -258,7 +258,7 @@ class Element
     else
       Log.error('[GRIDIUM::Element] Cannot jquery_click.  Element is not present.')
     end
-  end  
+  end
 
   def size
     element.size

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -78,16 +78,14 @@ class Element
   # ================ #
 
   # soft failure, will not kill test immediately
-  def verify(timeout: nil)
+  def verify(timeout: Gridium.config.element_timeout)
     Log.debug('[GRIDIUM::Element] Verifying new element...')
-    timeout = Gridium.config.element_timeout if timeout.nil?
     ElementVerification.new(self, timeout)
   end
 
   # hard failure, will kill test immediately
-  def wait_until(timeout: nil)
+  def wait_until(timeout: Gridium.config.element_timeout)
     Log.debug('[GRIDIUM::Element] Waiting for new element...')
-    timeout = Gridium.config.element_timeout if timeout.nil?
     ElementVerification.new(self, timeout, fail_test: true)
   end
 
@@ -98,8 +96,6 @@ class Element
   def css_value(name)
     element.css_value(name)
   end
-
-
 
   def present?
     return element.enabled?

--- a/lib/element_verification.rb
+++ b/lib/element_verification.rb
@@ -29,10 +29,10 @@ class Gridium::ElementVerification
     end
 
     if should_have_text
-      fail_message = "Element should contain text (#{text}), but does not."
+      fail_message = "Element should contain text (#{text}), but does not. timed out after #{@timeout} seconds"
       pass_message = "contains text (#{text})."
     else
-      fail_message = "Element should not contain text (#{text}), but does."
+      fail_message = "Element should not contain text (#{text}), but does. timed out after #{@timeout} seconds"
       pass_message = "does not contain text (#{text}).  Actual text is: (#{element_text})."
     end
 
@@ -49,6 +49,7 @@ class Gridium::ElementVerification
           ElementExtensions.highlight(@element) if Gridium.config.highlight_verifications
           log_success(pass_message)
         else
+          # TODO: @rizzza: This `.not` case is wrong. It bails too early and does not evaluate with the wait block
           log_issue("#{fail_message}  Element's text is: (#{element_text}).")
         end
       end
@@ -62,17 +63,17 @@ class Gridium::ElementVerification
     should_be_visible = @should_exist
 
     if should_be_visible
-      fail_message = "Element should be visible."
+      fail_message = "Element should be visible. timed out after #{@timeout} seconds"
       pass_message = "Element is visible."
     else
-      fail_message = "Element should not be visible."
+      fail_message = "Element should not be visible. timed out after #{@timeout} seconds"
       pass_message = "Element is not visible."
     end
 
     wait = Selenium::WebDriver::Wait.new :timeout => @timeout, :interval => 1
     begin
       wait.until do
-        element_is_displayed = @element.displayed?
+        element_is_displayed = @element.element(timeout: @timeout).displayed?
         if element_is_displayed && should_be_visible
           ElementExtensions.highlight(@element) if Gridium.config.highlight_verifications
           log_success(pass_message)
@@ -81,6 +82,7 @@ class Gridium::ElementVerification
           Log.debug("[GRIDIUM::ElementVerification] Confirming element is NOT visible...")
           log_success(pass_message)
         else
+          # TODO: @rizzza: This `.not` case is wrong. It bails too early and does not evaluate with the wait block
           log_issue(fail_message)
         end
       end
@@ -94,17 +96,17 @@ class Gridium::ElementVerification
     should_be_present = @should_exist
 
     if should_be_present
-      fail_message = "Element should be present."
+      fail_message = "Element should be present. timed out after #{@timeout} seconds"
       pass_message = "is present."
     else
-      fail_message = "Element should NOT be present."
+      fail_message = "Element should NOT be present. timed out after #{@timeout} seconds"
       pass_message = "is not present."
     end
 
     wait = Selenium::WebDriver::Wait.new :timeout => @timeout, :interval => 1
     begin
       wait.until do
-        element_is_present = @element.present?
+        element_is_present = @element.element(timeout: @timeout).present?
         if element_is_present && should_be_present
           ElementExtensions.highlight(@element) if Gridium.config.highlight_verifications
           log_success(pass_message)
@@ -113,6 +115,7 @@ class Gridium::ElementVerification
           Log.debug("[GRIDIUM::ElementVerification] Confirming element is NOT present...")
           log_success(pass_message)
         else
+          # TODO: @rizzza: This `.not` case is wrong. It bails too early and does not evaluate with the wait block
           log_issue(fail_message)
         end
       end
@@ -147,7 +150,7 @@ class Gridium::ElementVerification
     if @fail_test
       Log.error("[GRIDIUM::ElementVerification] #{message} ['#{@element.name}' (By:(#{@element.by} => '#{@element.locator}'))].")
       $fail_test_instantly = true
-      Kernel.fail(message)
+      raise Selenium::WebDriver::Error::TimeOutError, message
     else
       Log.error("[GRIDIUM::ElementVerification] #{message} ['#{@element.name}' (By:(#{@element.by} => '#{@element.locator}'))].")
       $fail_test_at_end = true

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -89,6 +89,8 @@ module Gridium
       Timeout.timeout(Gridium.config.page_load_timeout) do
         loop until jquery_loaded?
       end
+    rescue Timeout::Error => e
+      Log.warn("[GRIDIUM::Page] Timed-out waiting for ajax")
     end
 
     def self.jquery_loaded?
@@ -98,9 +100,9 @@ module Gridium
     #
     # JQuery click
     # @param [String] CSS selector
-    # 
-    # Occasionaly selenium is unable to click on elements in the DOM which have some 
-    # interesting React goodies around the element. 
+    #
+    # Occasionaly selenium is unable to click on elements in the DOM which have some
+    # interesting React goodies around the element.
     #
     def self.jquery_click(selector)
       Driver.evaluate_script("$(\"#{selector}\").click().change();")

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -315,13 +315,24 @@ describe Driver do
   end
 
   describe 'creating new page elements' do
-    it 'creates new Gridium Elements' do
+    it 'creates and waits with verify for new Gridium Elements' do
       test_driver.visit(test_url)
       element_one = create_new_element('ele1', :css, '#lst-ib')
       element_one.send_keys 'sendgrid'
 
-      element_two = create_new_element('ele2', :xpath, "//div[@id='search']//b[contains(.,'sendgrid')]")
-      element_two.verify.present
+      element_two = create_new_element('ele2', :xpath, "//div[@id='search']//*[contains(.,'sendgrid')]")
+      element_two.verify.visible
+
+      expect($verification_passes).to be < 4
+    end
+
+    it 'creates and waits with wait_until for new Gridium Elements' do
+      test_driver.visit(test_url)
+      element_one = create_new_element('ele1', :css, '#lst-ib')
+      element_one.send_keys 'sendgrid'
+
+      element_two = create_new_element('ele2', :xpath, "//div[@id='search']//*[contains(.,'sendgrid')]")
+      element_two.wait_until.visible
 
       expect($verification_passes).to be < 4
     end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -19,6 +19,16 @@ describe Element do
     Driver.quit
   end
 
+  context 'when element does not exist' do
+    context 'with default element timeout' do
+      it 'raises TimeOutError' do
+        msg = /timed out after #{Gridium.config.element_timeout} seconds/
+        expect { Element.new("Unknown element", :css, ".invalid-css").click }.to \
+          raise_error(Selenium::WebDriver::Error::TimeOutError, msg)
+      end
+    end
+  end
+
   describe '#verify' do
     xit 'verifies new element and logs it' do
       allow(logger).to receive(:debug)
@@ -52,6 +62,46 @@ describe Element do
       skip("skip until wait_until.not.visible works")
       vanishing_div = Element.new("I am jack's disappearing div", :id, element_to_vanish_id)
       vanishing_div.wait_until(timeout: wait_timeout).not.visible
+    end
+
+    context 'when element does not exist' do
+      context 'with explicit wait timeout' do
+        it 'raises TimeOutError' do
+          msg = /timed out after #{wait_timeout} seconds/
+          expect { Element.new("Unknown element", :css, ".invalid-css").wait_until(timeout: wait_timeout).visible.click }.to \
+            raise_error(Selenium::WebDriver::Error::TimeOutError, msg)
+        end
+
+        it 'timeouts within requested time in seconds' do
+          time = Benchmark.realtime do
+            msg = /timed out after #{wait_timeout} seconds/
+            expect { Element.new("Unknown element", :css, ".invalid-css").wait_until(timeout: wait_timeout).visible.click }.to \
+            raise_error(Selenium::WebDriver::Error::TimeOutError, msg)
+          end
+
+          expect(time).to be_within(3).of(wait_timeout), "Expected #{time} to be within 3 seconds of explicit wait timeout '#{wait_timeout}'"
+        end
+      end
+    end
+
+    context 'when element exists' do
+      context 'with explicit wait timeout' do
+        it 'raises TimeOutError on waiting to NOT be visible' do
+          msg = /timed out after #{wait_timeout} seconds/
+          expect { Element.new("Known element", :id, element_to_appear_id).wait_until(timeout: wait_timeout).not.visible }.to \
+            raise_error(Selenium::WebDriver::Error::TimeOutError, msg)
+        end
+
+        it 'timeouts within requested time in seconds' do
+          time = Benchmark.realtime do
+            msg = /timed out after #{wait_timeout} seconds/
+            expect { Element.new("Known element", :id, element_to_appear_id).wait_until(timeout: wait_timeout).not.visible }.to \
+            raise_error(Selenium::WebDriver::Error::TimeOutError, msg)
+          end
+
+          expect(time).to be_within(3).of(wait_timeout), "Expected #{time} to be within 3 seconds of explicit wait timeout '#{wait_timeout}'"
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require 'rspec'
 require 'gridium'
 require 'page_objects/google_home'
 require 'dotenv'
+require 'benchmark'
 
 #Load settings from .env file - S3 and TestRail Info
 Dotenv.load '.env'


### PR DESCRIPTION
Remove the implicit wait and default explicit wait to 15 seconds per the Gridium config.

Not only is this the preferred way to execute waits, the `NLVX Campaigns Index Spec` has a test to create template from campaign, which in docker-land may take up to 20-25 seconds.... Implicit waits are failing for that. 