### PR TITLE
Extend Page has_text? with visibility and timeout

### DIFF
--- a/lib/element.rb
+++ b/lib/element.rb
@@ -23,6 +23,8 @@ class Element
 
     #how long to wait between clearing an input and sending keys to it
     @text_padding_time = 0.15
+
+    @default_timeout = Gridium.config.element_timeout
   end
 
   def to_s
@@ -30,7 +32,7 @@ class Element
   end
 
   def element(opts = {})
-    timeout = opts[:timeout].nil? ? Gridium.config.element_timeout : opts[:timeout]
+    timeout = opts[:timeout].nil? ? @default_timeout : opts[:timeout]
 
     if stale?
       wait = Selenium::WebDriver::Wait.new :timeout => timeout, :interval => 1

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -48,17 +48,23 @@ module Gridium
       end
     end
 
-    def self.has_text?(text)
-      has_flash?(text)
+
+    def self.has_text?(text, opts = {})
+      has_flash?(text, opts)
     end
 
-    def self.has_flash?(text)
-      wait = Selenium::WebDriver::Wait.new(:timeout => 5) #5 seconds every 500ms
+    def self.has_flash?(text, opts = {})
+      timeout = opts[:timeout] || 5
+      wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
       begin
-        element = wait.until {Driver.html.include? text}
+        if opts[:visible]
+          element = wait.until { Element.new("Finding text '#{text}'", :xpath, "//*[text()='#{text}']").displayed? }
+        else
+          element = wait.until { Driver.html.include? text }
+        end
       rescue Exception => exception
-        Log.debug("[GRIDIUM::Page] has_flash? exception was rescued: #{exception}")
-        Log.warn("[GRIDIUM::Page] Could not find the flash message!")
+        Log.debug("[GRIDIUM::Page] exception was rescued: #{exception}")
+        Log.warn("[GRIDIUM::Page] Could not find the text '#{text}'!")
       end
 
       if element
@@ -122,7 +128,7 @@ module Gridium
     end
 
     def click_on(text)
-      Element.new("Clicking #{text}", :xpath, "//*[text()='#{text}')]").click
+      Element.new("Clicking #{text}", :xpath, "//*[text()='#{text}']").click
     end
 
     # Click the link on the page

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -7,7 +7,14 @@ describe Page do
   let(:test_driver) { Driver }
   let(:test_page) { Page }
   let(:logger) { Log }
-  let(:the_internet_url) {'http://the-internet:5000'}
+  let(:the_internet_url) { 'http://the-internet:5000' }
+  let(:jquery_menu_url) { "#{the_internet_url}/jqueryui/menu" }
+
+  before :all do
+    Gridium.config.browser_source = :remote
+    Gridium.config.target_environment = "http://hub:4444/wd/hub"
+    Gridium.config.browser = :chrome
+  end
 
   after :each do
     test_driver.quit
@@ -131,6 +138,36 @@ describe Page do
       new_page_object = status_code_page.refresh
       expect(new_page_object.class).to eq StatusCodes
     end
+  end
 
+  describe '#has_text?' do
+    before do
+      test_driver.visit the_internet_url
+    end
+
+    it 'finds text in all page source' do
+      expect(Page.has_text?("Elemental Selenium")).to be true
+    end
+
+    it 'fails to find text in all page source' do
+      test_driver.visit jquery_menu_url
+      expect(Page.has_text?("Non-elemental Selenium", timeout: 2)).to be false
+    end
+
+    context 'with visible' do
+      it 'finds only visible text' do
+        expect(Page.has_text?("Elemental Selenium", visible: true)).to be true
+      end
+
+      it 'finds non-visible text in all page source' do
+        test_driver.visit jquery_menu_url
+        expect(Page.has_text?("Back to JQuery UI", visible: false)).to be true
+      end
+
+      it 'fails to find non-visible text' do
+        test_driver.visit jquery_menu_url
+        expect(Page.has_text?("Back to JQuery UI", visible: true, timeout: 5)).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
`Page.has_text?` currently searches through all the `page_source` to find text. There may be cases where the text is in the source, but not visible. 

- [x] Added optional arg `visible`
- [x] Added optional arg `timeout`

Example:
`Page.has_text?("Not there", visible: true, timeout: 2)`

- [x] Fixed `Page.new.click_on(text)` 🐛 