### PR TITLE
QEA-1671: Update mouse_over

### DIFF
--- a/lib/element_extensions.rb
+++ b/lib/element_extensions.rb
@@ -1,50 +1,49 @@
 include Gridium
 
 class Gridium::ElementExtensions
-  def self.highlight(element)
-    Log.debug("[GRIDIUM::ElementExtensions] Highlighting element...")
-    original_border = Driver.execute_script("return arguments[0].style.border", element.element)
-    original_background = Driver.execute_script("return arguments[0].style.backgroundColor", element.element)
-    Driver.execute_script("arguments[0].style.border='3px solid lime'; return;", element.element)
-    Driver.execute_script("arguments[0].style.backgroundColor='lime'; return;", element.element)
-    sleep (Gridium.config.highlight_duration)
-    Driver.execute_script("arguments[0].style.border='" + original_border + "'; return;", element.element)
-    Driver.execute_script("arguments[0].style.backgroundColor='" + original_background + "'; return;", element.element)
-  end
+  class << self
+    def highlight(element)
+      Log.debug("[GRIDIUM::ElementExtensions] Highlighting element...")
+      original_border = Driver.execute_script("return arguments[0].style.border", element.element)
+      original_background = Driver.execute_script("return arguments[0].style.backgroundColor", element.element)
+      Driver.execute_script("arguments[0].style.border='3px solid lime'; return;", element.element)
+      Driver.execute_script("arguments[0].style.backgroundColor='lime'; return;", element.element)
+      sleep (Gridium.config.highlight_duration)
+      Driver.execute_script("arguments[0].style.border='" + original_border + "'; return;", element.element)
+      Driver.execute_script("arguments[0].style.backgroundColor='" + original_background + "'; return;", element.element)
+    end
 
-  def self.scroll_to(element)
-    Log.debug("[GRIDIUM::ElementExtensions] Scrolling element into view...")
-    Driver.execute_script("arguments[0].scrollIntoView(); return;", element.element)
-    sleep 1
-  end
+    def scroll_to(element)
+      Log.debug("[GRIDIUM::ElementExtensions] Scrolling element into view...")
+      Driver.execute_script("arguments[0].scrollIntoView(); return;", element.element)
+      sleep 1
+    end
 
-  def self.hover_over(element)
-    Driver.execute_script("var evObj = document.createEvent('MouseEvents'); evObj.initMouseEvent(\"mouseover\",true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null); arguments[0].dispatchEvent(evObj);", element.element)
-    sleep 2
-  end
+    def hover_away(element)
+      Driver.execute_script("var evObj = document.createEvent('MouseEvents'); evObj.initMouseEvent(\"mouseout\",true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null); arguments[0].dispatchEvent(evObj);", element.element)
+      sleep 1
+    end
 
-  def self.hover_away(element)
-    Driver.execute_script("var evObj = document.createEvent('MouseEvents'); evObj.initMouseEvent(\"mouseout\",true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null); arguments[0].dispatchEvent(evObj);", element.element)
-    sleep 1
-  end
+    #
+    # Mouse over the requested element at coordinate (Default x:0, y:0)
+    # @param [Element] element
+    # @param [Integer] x - element x coordinate
+    # @param [Integer] y - element y coordinate
+    #
+    def mouse_over(element, x: 0, y: 0)
+      Driver.driver.action.move_to(element.element, x, y).perform
+    end
 
-  #
-  # Mouse over the requested element at coordinate (Default x:0, y:0)
-  # @param [Element] element
-  # @param [Integer] x - element x coordinate
-  # @param [Integer] y - element y coordinate
-  #
-  def self.mouse_over(element, x: 0, y: 0)
-    Driver.driver.action.move_to(element.element, x, y).perform
-  end
+    alias_method :hover_over, :mouse_over
 
-  def self.trigger_onblur(element)
-    Driver.execute_script("arguments[0].focus(); arguments[0].blur(); return true", element.element)
-  end
+    def trigger_onblur(element)
+      Driver.execute_script("arguments[0].focus(); arguments[0].blur(); return true", element.element)
+    end
 
-  # Occasionaly selenium is unable to click on elements in the DOM which have some
-  # interesting React goodies around the element.
-  def self.jquery_click(element)
-    Driver.execute_script("arguments[0].click().change();", element.element)
+    # Occasionaly selenium is unable to click on elements in the DOM which have some
+    # interesting React goodies around the element.
+    def jquery_click(element)
+      Driver.execute_script("arguments[0].click().change();", element.element)
+    end
   end
 end

--- a/lib/element_extensions.rb
+++ b/lib/element_extensions.rb
@@ -28,15 +28,21 @@ class Gridium::ElementExtensions
     sleep 1
   end
 
-  def self.mouse_over(element)
-    Driver.driver.mouse.move_to(element.element)
+  #
+  # Mouse over the requested element at coordinate (Default x:0, y:0)
+  # @param [Element] element
+  # @param [Integer] x - element x coordinate
+  # @param [Integer] y - element y coordinate
+  #
+  def self.mouse_over(element, x: 0, y: 0)
+    Driver.driver.action.move_to(element.element, x, y).perform
   end
 
   def self.trigger_onblur(element)
     Driver.execute_script("arguments[0].focus(); arguments[0].blur(); return true", element.element)
   end
 
-  # Occasionaly selenium is unable to click on elements in the DOM which have some 
+  # Occasionaly selenium is unable to click on elements in the DOM which have some
   # interesting React goodies around the element.
   def self.jquery_click(element)
     Driver.execute_script("arguments[0].click().change();", element.element)

--- a/lib/page.rb
+++ b/lib/page.rb
@@ -58,7 +58,7 @@ module Gridium
       wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
       begin
         if opts[:visible]
-          element = wait.until { Element.new("Finding text '#{text}'", :xpath, "//*[text()='#{text}']").displayed? }
+          element = wait.until { Element.new("Finding text '#{text}'", :xpath, "//*[text()=\"#{text}\"]").displayed? }
         else
           element = wait.until { Driver.html.include? text }
         end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -115,6 +115,23 @@ describe Element do
     end
   end
 
+  describe '#mouse_over / #hover_over' do
+    let(:hover_url) { "http://mustadio:3000/hover"}
+    let(:invisible_text) { "I am Jack's smirking div" }
+
+    it 'can mouse_over' do
+      test_driver.visit hover_url
+      Page.new.find(:id, "hover-target").mouse_over
+      expect(Page.has_text?(invisible_text, visible: true)).to be true
+    end
+
+    it 'can hover_over' do
+      test_driver.visit hover_url
+      Page.new.find(:id, "hover-target").hover_over
+      expect(Page.has_text?(invisible_text, visible: true)).to be true
+    end
+  end
+
   describe '#css_value' do
     it 'should return a css value' do
       Driver.visit the_internet_url
@@ -291,6 +308,5 @@ describe Element do
       this_one.clear
       expect {this_one.send(:field_empty_afterward?, desired_text)}.to  raise_error error=RuntimeError, message=expected_error
     end
-
   end
 end


### PR DESCRIPTION
Updating `ElementExtensions#mouse_over` to use action builder
`driver.mouse.move_to(element)` is deprecated.