### PR TITLE
Fix has_xxx? waiters

### DIFF
--- a/lib/page.rb
+++ b/lib/page.rb
@@ -22,11 +22,10 @@ module Gridium
       timeout = opts[:timeout] || 5
       wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
       begin
-        element = Driver.driver.find_element :css, css
         if opts[:visible]
-          wait.until {element.displayed?}
+          wait.until {Driver.driver.find_element(:css, css).displayed?}
         else
-          wait.until {element.enabled?}
+          wait.until {Driver.driver.find_element(:css, css).enabled?}
         end
       rescue Exception => exception
         Log.debug("[GRIDIUM::Page] has_css? is false because this exception was rescued: #{exception}")
@@ -38,11 +37,10 @@ module Gridium
       timeout = opts[:timeout] || 5
       wait = Selenium::WebDriver::Wait.new(:timeout => timeout)
       begin
-        element = Driver.driver.find_element :xpath, xpath
         if opts[:visible]
-          wait.until {element.displayed?}
+          wait.until {Driver.driver.find_element(:xpath, xpath).displayed?}
         else
-          wait.until {element.enabled?}
+          wait.until {Driver.driver.find_element(:xpath, xpath).enabled?}
         end
       rescue Exception => exception
         Log.debug("[GRIDIUM::Page] has_xpath? is false because this exception was rescued: #{exception}")

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -206,7 +206,19 @@ describe Page do
     end
 
     it 'fails to find non-existent css' do
-      expect(Page.has_css?(unknown_content, timeout: 2)).to be false
+      expect(Page.has_css?(unknown_content)).to be false
+    end
+
+    context 'with timeout' do
+      let(:wait_timeout) { 5 }
+
+      it 'timeouts within requested time in seconds' do
+        time = Benchmark.realtime do
+          expect(Page.has_css?(unknown_content, timeout: wait_timeout)).to be false
+        end
+
+        expect(time).to be_within(2).of(wait_timeout), "Expected #{time} to be within 2 seconds of requested timeout '#{wait_timeout}'"
+      end
     end
 
     context 'with visible' do
@@ -238,7 +250,19 @@ describe Page do
     end
 
     it 'fails to find non-existent xpath' do
-      expect(Page.has_xpath?(unknown_content, timeout: 2)).to be false
+      expect(Page.has_xpath?(unknown_content)).to be false
+    end
+
+    context 'with timeout' do
+      let(:wait_timeout) { 5 }
+
+      it 'timeouts within requested time in seconds' do
+        time = Benchmark.realtime do
+          expect(Page.has_xpath?(unknown_content, timeout: wait_timeout)).to be false
+        end
+
+        expect(time).to be_within(2).of(wait_timeout), "Expected #{time} to be within 2 seconds of requested timeout '#{wait_timeout}'"
+      end
     end
 
     context 'with visible' do


### PR DESCRIPTION
`find_element` should have been inside the `wait`s. Eventually, when we get the `timeout` related stuff re-factored, we can use `Element` here instead of straight up `Driver`