### PR TITLE
Page load timeout retry / loosen webdriver pin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in gridium.gemspec
 gemspec
+gem 'selenium-webdriver', '= 3.4.0'

--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ Gridium.configure do |config|
   config.browser_source = :local
   config.selenium_log_level = 'OFF' #OFF, SEVERE, WARNING, INFO, DEBUG, ALL https://github.com/SeleniumHQ/selenium/wiki/Logging
   config.target_environment = "Integration"
-  config.browser = :firefox
+  config.browser = :chrome
   config.url = "http://www.applicationundertest.com"
   config.page_load_timeout = 30
+  config.page_load_retry = 0
   config.element_timeout = 30
   config.visible_elements_only = true
   config.log_level = :debug
@@ -102,6 +103,7 @@ You may be saying to yourself - 'Holy Crap that's a lot of settings!'.  Yeah.  I
 `config.browser = :firefox`: This tells gridium which browser you will be testing.  Only firefox is working currently.  Future browsers to come.  
 `config.url = "http://www.applicationundertest.com"`: Where's the entry point for your web application?  
 `config.page_load_timeout = 30` Along with Element Timeout, how long (in seconds) should Selenium wait when finding an element?  
+`config.page_load_retry = 1` On a failure to load the requested page, Gridium will retry loading the page this many times.  
 `config.visible_elements_only = true`: With this enabled Gridium will only find VISIBLE elements on the page.  Hidden elements or non-enabled elements will not be matched.  
 `config.log_level = :debug`: There are a few levels here `:debug` `:info` `:warn` `:error` and `:fatal`.  Your Gridium tests objects can have different levels of logging.  Adjusting this setting will turn those log levels on or off depending on your needs at the time.  
 `config.highlight_verifications = true`: Will highlight the element Gridium finds in the browser.  This makes watching tests run easier to follow, although it does slow the test execution time down.  Recommend this is turned off for automated tests running in Jenkins or headless mode.  

--- a/gridium.gemspec
+++ b/gridium.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock", "~>2.3"
   spec.add_development_dependency "dotenv", "~>2.1"
 
-  spec.add_runtime_dependency "selenium-webdriver", "3.3.0"
+  spec.add_runtime_dependency "selenium-webdriver", "~> 3.3"
   spec.add_runtime_dependency "oily_png", "~> 1.2"
   spec.add_runtime_dependency 'aws-sdk', '~> 2'
 end

--- a/lib/element.rb
+++ b/lib/element.rb
@@ -183,11 +183,11 @@ class Element
     unless element.enabled?
       raise "Browser Error: tried to enter #{args} but the input is disabled"
     end
-    if only_symbols? *args
-      append_keys *args
+    if only_symbols?(*args)
+      append_keys(*args)
     else
-      _stomp_input_text *args
-      field_empty_afterward? *args
+      _stomp_input_text(*args)
+      field_empty_afterward?(*args)
     end
   end
   alias_method :text=, :send_keys
@@ -227,7 +227,7 @@ class Element
   end
 
   # Raw webdriver mouse over
-  def mouse_over(x: 0, y: 0)
+  def mouse_over(x: 1, y: 1)
     Log.debug("[GRIDIUM::Element] Triggering mouse over for (#{self.to_s})...")
     if element.enabled?
       $verification_passes += 1

--- a/lib/gridium.rb
+++ b/lib/gridium.rb
@@ -21,7 +21,7 @@ module Gridium
   end
 
   class Config
-    attr_accessor :report_dir, :browser_source, :target_environment, :browser, :url, :page_load_timeout, :element_timeout, :visible_elements_only, :log_level
+    attr_accessor :report_dir, :browser_source, :target_environment, :browser, :url, :page_load_timeout, :page_load_retries, :element_timeout, :visible_elements_only, :log_level
     attr_accessor :highlight_verifications, :highlight_duration, :screenshot_on_failure, :screenshots_to_s3, :project_name_for_s3, :subdirectory_name_for_s3
     attr_accessor :testrail, :selenium_log_level
 
@@ -33,6 +33,7 @@ module Gridium
       @browser = :chrome
       @url = "about:blank"
       @page_load_timeout = 15
+      @page_load_retries = 0
       @element_timeout = 15  #This needs to be changed to only look for an element after a page is done loading
       @visible_elements_only = true
       @log_level = :fatal

--- a/spec/gridium_spec.rb
+++ b/spec/gridium_spec.rb
@@ -2,7 +2,6 @@ require_relative 'spec_helper'
 # require 'pry'
 
 describe Gridium do
-
   describe 'Gridium' do
     let(:gridium_version) { Gridium::VERSION }
     let(:gridium_configuration) { Gridium.config }
@@ -18,7 +17,8 @@ describe Gridium do
         expect(gridium_configuration.target_environment).to eq('http://hub:4444/wd/hub')
         expect(gridium_configuration.browser).to eq(:chrome)
         expect(gridium_configuration.page_load_timeout).to eq(15)
-        expect(gridium_configuration.element_timeout).to eq (15)
+        expect(gridium_configuration.page_load_retries).to eq(0)
+        expect(gridium_configuration.element_timeout).to eq(15)
         expect(gridium_configuration.visible_elements_only).to be(true)
         expect(gridium_configuration.log_level).to eq(:error)
         expect(gridium_configuration.highlight_verifications).to be(true)


### PR DESCRIPTION
- [x] Removing `selenium-webdriver` version pin
- [x] Adding a page load timeout mechanism 
```ruby
Gridium.configure do |c|
  c.page_load_retry = 2
```
- [x] Fix some rubocop issues
- [x] `Update mouse_over` default coordinates