### PR TITLE
Element#set_attribute : search by css, then id

### DIFF
--- a/lib/element.rb
+++ b/lib/element.rb
@@ -94,14 +94,22 @@ class Element
     element.attribute(name)
   end
 
-  # Requires element to have an ID value, to successfully use `document.getElementById`
+  # Requires element to have an unique css
+  # @param [String] name - attribute name
+  # @param [String] value - attribute value to set
   def set_attribute(name, value)
-    id = self.attribute('id')
-    if id.nil? || id.empty?
-      Log.warn("[GRIDIUM::Element] #{self} does not have an 'id'. Consider adding one.")
+    Log.debug("[GRIDIUM::Element] setting element attribute '#{name}' to '#{value}'")
+
+    if self.by == :css
+      ElementExtensions.set_attribute(self.locator, name, value)
     else
-      Log.debug("[GRIDIUM::Element] setting element attribute '#{name}' to '#{value}'")
-      ElementExtensions.set_attribute(id, name, value)
+      # see if the element has an id to work with
+      id = self.attribute('id')
+      if id.nil? || id.empty?
+        Log.warn("[GRIDIUM::Element] #{self} does not have an 'id'. Consider adding one.")
+      else
+        ElementExtensions.set_attribute("[id=#{id}", name, value)
+      end
     end
   end
 

--- a/lib/element_extensions.rb
+++ b/lib/element_extensions.rb
@@ -59,12 +59,12 @@ class Gridium::ElementExtensions
 
     #
     # Use Javascript to set element attribute value from :id
-    # @param [String] id
-    # @param [String] Attribute
-    # @param [String] value
+    # @param [String] selector  - css selector for find element by
+    # @param [String] attribute - element attribute to set
+    # @param [String] value     - element value to set
     #
-    def set_attribute(id, attr, val)
-      Driver.execute_script_driver("document.getElementById('#{id}').setAttribute('#{attr}', '#{val}')");
+    def set_attribute(selector, attr, val)
+      Driver.execute_script_driver("document.querySelectorAll('#{selector}')[0].setAttribute('#{attr}', '#{val}')")
     end
   end
 end

--- a/spec/element_spec.rb
+++ b/spec/element_spec.rb
@@ -502,9 +502,9 @@ describe Element do
         end
       end
 
-      context 'with element not having an #id attributge' do
+      context 'with element not having an #id attribute' do
         it 'silently fails and logs a message' do
-          Page.new.find(:css, "a[href*=elementalselenium]").set_attribute('class', new_class_value)
+          Page.new.find(:xpath, "//a[contains(@href,'elementalselenium')]").set_attribute('class', new_class_value)
           expect(Log).to have_received(:warn).with(/does not have an 'id'/)
         end
       end


### PR DESCRIPTION
Loosen up the constraint on setting the attribute by using `document.querySelectorAll` rather than `getElementById`